### PR TITLE
Move subject-area-client-samples README to correct subdir and rename …

### DIFF
--- a/open-metadata-implementation/access-services/asset-lineage/asset-lineage-server/src/main/java/org/odpi/openmetadata/accessservices/assetlineage/handlers/ProcessContextHandler.java
+++ b/open-metadata-implementation/access-services/asset-lineage/asset-lineage-server/src/main/java/org/odpi/openmetadata/accessservices/assetlineage/handlers/ProcessContextHandler.java
@@ -87,9 +87,8 @@ public class ProcessContextHandler {
 
         List<Relationship> processPorts = handlerHelper.getRelationshipsByType(userId, processGUID, PROCESS_PORT, PROCESS);
         if (CollectionUtils.isEmpty(processPorts)) {
-            log.error("No relationships Process Port has been found for the entity with guid {}", processGUID);
-
-            throw new AssetLineageException(RELATIONSHIP_NOT_FOUND.getMessageDefinition(), this.getClass().getName(), "Retrieving Relationship");
+            log.warn("No relationships Process Port has been found for the Process with guid {}", processGUID);
+            return ArrayListMultimap.create();
         }
 
         RelationshipsContext relationshipsContext = handlerHelper.buildContextForRelationships(userId, processGUID, processPorts);
@@ -169,8 +168,7 @@ public class ProcessContextHandler {
                     relationshipsContext);
 
             if (tabularColumn == null) {
-                log.error("No entity TabularColumn has been found for the PortImplementation with guid {}", port.getGUID());
-                throw new AssetLineageException(RELATIONSHIP_NOT_FOUND.getMessageDefinition(), this.getClass().getName(), "Retrieving Relationship");
+                log.warn("No entity TabularColumn has been found for the PortImplementation with guid {}", port.getGUID());
             }
         }
     }

--- a/open-metadata-implementation/user-interfaces/ui-chassis/ui-chassis-spring/src/main/java/org/odpi/openmetadata/userinterface/uichassis/springboot/api/settings/AppBean.java
+++ b/open-metadata-implementation/user-interfaces/ui-chassis/ui-chassis-spring/src/main/java/org/odpi/openmetadata/userinterface/uichassis/springboot/api/settings/AppBean.java
@@ -13,16 +13,25 @@ import java.io.Serializable;
 @Component
 public class AppBean implements Serializable {
     private final String title;
+    private final String description;
 
-    public AppBean(@Value("${app.title: }") String title){
+    public AppBean(@Value("${app.title: }") String title,
+                   @Value("${app.description: }") String description){
         this.title = title;
+        this.description = description;
     }
 
     /**
-     *
      * @return title field
      */
     public String getTitle() {
         return title;
+    }
+
+    /**
+     * @return description field
+     */
+    public String getDescription() {
+        return description;
     }
 }

--- a/open-metadata-implementation/user-interfaces/ui-chassis/ui-chassis-spring/src/main/java/org/odpi/openmetadata/userinterface/uichassis/springboot/api/settings/PublicController.java
+++ b/open-metadata-implementation/user-interfaces/ui-chassis/ui-chassis-spring/src/main/java/org/odpi/openmetadata/userinterface/uichassis/springboot/api/settings/PublicController.java
@@ -14,9 +14,6 @@ import javax.servlet.http.HttpServletRequest;
 @RequestMapping("/api/public")
 public class PublicController {
 
-    @Value("${theme:default}")
-    String theme;
-
     @Autowired
     AppBean app;
 


### PR DESCRIPTION
…Subject-Area-Definitions-creation.md

Fixes issue #5166 by moving around the README.md files that were
misplaced in access-services-samples/subject-area-client-samples/