### PR TITLE
#5609 add clear registration for cohort to server author

### DIFF
--- a/open-metadata-implementation/view-services/server-author-view/server-author-view-server/src/main/java/org/odpi/openmetadata/viewservices/serverauthor/handlers/ServerAuthorViewHandler.java
+++ b/open-metadata-implementation/view-services/server-author-view/server-author-view-server/src/main/java/org/odpi/openmetadata/viewservices/serverauthor/handlers/ServerAuthorViewHandler.java
@@ -750,6 +750,7 @@ public class ServerAuthorViewHandler {
      * information and events related to changes in their supported metadata types and instances.
      * They are also able to query each other's metadata directly through REST calls.
      *
+     * @param serverToBeConfiguredName  server being configured
      * @param cohortName  name of the cohort.
      * @throws ServerAuthorViewServiceException error occurred during the registration of the cohort
      */
@@ -770,6 +771,30 @@ public class ServerAuthorViewHandler {
             // if we have a configuration error, this is likely because we could not contact the platform using the platform root URL
             // configured in this view service.
            throw ServerAuthorExceptionHandler.mapOMAGConfigurationErrorException(className, methodName, error);
+        }
+    }
+    /**
+     * Unregister this server from an open metadata repository cohort.
+     *
+     * @param serverToBeConfiguredName  server being configured
+     * @param cohortName  name of the cohort.
+     * @throws ServerAuthorViewServiceException error occurred during the unregistration of the cohort
+     */
+    public void removeCohortRegistration(String serverToBeConfiguredName, String cohortName ) throws ServerAuthorViewServiceException {
+        final String methodName = "removeCohortRegistration";
+        try {
+            MetadataServerConfigurationClient client = new MetadataServerConfigurationClient(this.userId,
+                                                                                             serverToBeConfiguredName,
+                                                                                             this.platformURL);
+            client.clearCohortRegistration(cohortName);
+        } catch (OMAGInvalidParameterException error) {
+            throw ServerAuthorExceptionHandler.mapOMAGInvalidParameterException(className, methodName, error);
+        } catch (OMAGNotAuthorizedException error) {
+            throw ServerAuthorExceptionHandler.mapToUserNotAuthorizedException(className, methodName);
+        } catch (OMAGConfigurationErrorException error) {
+            // if we have a configuration error, this is likely because we could not contact the platform using the platform root URL
+            // configured in this view service.
+            throw ServerAuthorExceptionHandler.mapOMAGConfigurationErrorException(className, methodName, error);
         }
     }
 }

--- a/open-metadata-implementation/view-services/server-author-view/server-author-view-server/src/main/java/org/odpi/openmetadata/viewservices/serverauthor/services/ServerAuthorViewRESTServices.java
+++ b/open-metadata-implementation/view-services/server-author-view/server-author-view-server/src/main/java/org/odpi/openmetadata/viewservices/serverauthor/services/ServerAuthorViewRESTServices.java
@@ -890,8 +890,36 @@ public class ServerAuthorViewRESTServices {
             log.debug("Returning from method: " + methodName + " with response: " + response.toString());
         }
         return response;
+    }
+    /**
+     * Unregister this server from an open metadata repository cohort.
+     *
+     * @param userId  user that is issuing the request.
+     * @param serverName  local server name.
+     * @param cohortName  name of the cohort.
+     * @return void response or
+     * OMAGNotAuthorizedException the supplied userId is not authorized to issue this command or
+     * OMAGInvalidParameterException invalid serverName, cohortName or serviceMode parameter.
+     */
+    public VoidResponse removeCohortRegistration(String userId, String serverName, String serverToBeConfiguredName, String cohortName) {
+        String methodName = "removeCohortRegistration";
+        if (log.isDebugEnabled()) {
+            log.debug("Entering method: " + methodName + " with serverName " + serverName + " server To Be Configured Name " + serverToBeConfiguredName);
+        }
+        VoidResponse response = new VoidResponse();
 
-
-
+        AuditLog auditLog = null;
+        try {
+            auditLog = instanceHandler.getAuditLog(userId, serverName, methodName);
+            // unregister cohort
+            ServerAuthorViewHandler handler = instanceHandler.getServerAuthorViewHandler(userId, serverName, methodName);
+            handler.removeCohortRegistration(serverToBeConfiguredName, cohortName);
+        } catch (Exception exception) {
+            restExceptionHandler.captureExceptions(response, exception, methodName, auditLog);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Returning from method: " + methodName + " with response: " + response.toString());
+        }
+        return response;
     }
 }

--- a/open-metadata-implementation/view-services/server-author-view/server-author-view-spring/src/main/java/org/odpi/openmetadata/viewservices/serverauthor/server/spring/ConfigRepositoryServicesViewResource.java
+++ b/open-metadata-implementation/view-services/server-author-view/server-author-view-spring/src/main/java/org/odpi/openmetadata/viewservices/serverauthor/server/spring/ConfigRepositoryServicesViewResource.java
@@ -258,5 +258,24 @@ class ConfigRepositoryServicesViewResource {
     {
         return serverAPI.addCohortRegistration(userId, serverName, serverToBeConfiguredName,  cohortName);
     }
+    /**
+     * Unregister this server from an open metadata repository cohort.
+     *
+     * @param userId  user that is issuing the request.
+     * @param serverName  local server name.
+     * @param cohortName  name of the cohort.
+     * @return void response or
+     * OMAGNotAuthorizedException the supplied userId is not authorized to issue this command or
+     * OMAGInvalidParameterException invalid serverName, cohortName or serviceMode parameter.
+     */
+    @DeleteMapping(path = "/cohorts/{cohortName}")
+    public VoidResponse removeCohortRegistration(@PathVariable                String               userId,
+                                              @PathVariable                   String               serverName,
+                                              @PathVariable                   String               serverToBeConfiguredName,
+                                              @PathVariable                   String               cohortName)
+    {
+        return serverAPI.removeCohortRegistration(userId, serverName, serverToBeConfiguredName,  cohortName);
+    }
+
 
 }


### PR DESCRIPTION
Signed-off-by: David Radley <david_radley@uk.ibm.com>

<!-- SPDX-License-Identifier: CC-BY-4.0 -->
<!-- Copyright Contributors to the Egeria project. -->
# Description

Introduce a server author API to clear to cohort registration from a server configuration. This calls the existing admin client. 

Fixes #5609

# How Has This Been Tested?

This has been tested using the React UI

# Any additional notes for reviewers?

