### PR TITLE
(Release 3.1) Deprecate ArrayDocumentType & SetDocumentType #5614

### DIFF
--- a/open-metadata-resources/open-metadata-archives/open-metadata-types/src/main/java/org/odpi/openmetadata/opentypes/OpenMetadataTypesArchive.java
+++ b/open-metadata-resources/open-metadata-archives/open-metadata-types/src/main/java/org/odpi/openmetadata/opentypes/OpenMetadataTypesArchive.java
@@ -1410,6 +1410,8 @@ public class OpenMetadataTypesArchive
         this.archiveBuilder.addTypeDefPatch(deprecateArraySchemaType());
         this.archiveBuilder.addTypeDefPatch(deprecateArrayDocumentType());
         this.archiveBuilder.addTypeDefPatch(deprecateSetSchemaType());
+        this.archiveBuilder.addTypeDefPatch(deprecateSetDocumentType());
+
     }
 
 
@@ -1486,13 +1488,31 @@ public class OpenMetadataTypesArchive
     }
 
     /**
-     * Deprecate the BoundedSchemaType
+     * Deprecate the SetSchemaType
      *
      * @return patch
      */
     private TypeDefPatch deprecateSetSchemaType()
     {
         final String typeName = "SetSchemaType";
+
+        TypeDefPatch typeDefPatch = archiveBuilder.getPatchForType(typeName);
+
+        typeDefPatch.setUpdatedBy(originatorName);
+        typeDefPatch.setUpdateTime(creationDate);
+        typeDefPatch.setTypeDefStatus(TypeDefStatus.DEPRECATED_TYPEDEF);
+
+        return typeDefPatch;
+    }
+
+    /**
+     * Deprecate the SetDocumentType
+     *
+     * @return patch
+     */
+    private TypeDefPatch deprecateSetDocumentType()
+    {
+        final String typeName = "SetDocumentType";
 
         TypeDefPatch typeDefPatch = archiveBuilder.getPatchForType(typeName);
 


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

<!-- SPDX-License-Identifier: CC-BY-4.0 -->
<!-- Copyright Contributors to the Egeria project. -->
# Description

Deprecates ArrayDocumentType & SetDocumentType

See #5614

# How Has This Been Tested?

By postman/REST api call on main
By checking TEX works

# Any additional notes for reviewers?
See #5615 for further changes specific to master

