### PR TITLE
Removes result ordering from find-all performance tests

### DIFF
--- a/open-metadata-conformance-suite/open-metadata-conformance-suite-server/src/main/java/org/odpi/openmetadata/conformance/tests/performance/search/TestEntityHistorySearch.java
+++ b/open-metadata-conformance-suite/open-metadata-conformance-suite-server/src/main/java/org/odpi/openmetadata/conformance/tests/performance/search/TestEntityHistorySearch.java
@@ -130,7 +130,7 @@ public class TestEntityHistorySearch extends OpenMetadataPerformanceTestCase
                     null,
                     asOfTime,
                     null,
-                    SequencingOrder.GUID,
+                    null,
                     performanceWorkPad.getMaxSearchResults());
             long elapsedTime = (System.nanoTime() - start) / 1000000;
 
@@ -160,7 +160,7 @@ public class TestEntityHistorySearch extends OpenMetadataPerformanceTestCase
                         null,
                         null,
                         null,
-                        SequencingOrder.GUID,
+                        null,
                         performanceWorkPad.getMaxSearchResults());
                 elapsedTime = (System.nanoTime() - start) / 1000000;
                 if (results != null && !results.isEmpty()) {

--- a/open-metadata-conformance-suite/open-metadata-conformance-suite-server/src/main/java/org/odpi/openmetadata/conformance/tests/performance/search/TestEntitySearch.java
+++ b/open-metadata-conformance-suite/open-metadata-conformance-suite-server/src/main/java/org/odpi/openmetadata/conformance/tests/performance/search/TestEntitySearch.java
@@ -124,7 +124,7 @@ public class TestEntitySearch extends OpenMetadataPerformanceTestCase
                     null,
                     null,
                     null,
-                    SequencingOrder.GUID,
+                    null,
                     performanceWorkPad.getMaxSearchResults());
             long elapsedTime = (System.nanoTime() - start) / 1000000;
 
@@ -161,7 +161,7 @@ public class TestEntitySearch extends OpenMetadataPerformanceTestCase
                         null,
                         null,
                         null,
-                        SequencingOrder.GUID,
+                        null,
                         performanceWorkPad.getMaxSearchResults());
                 elapsedTime = (System.nanoTime() - start) / 1000000;
                 if (results != null && !results.isEmpty()) {

--- a/open-metadata-conformance-suite/open-metadata-conformance-suite-server/src/main/java/org/odpi/openmetadata/conformance/tests/performance/search/TestRelationshipHistorySearch.java
+++ b/open-metadata-conformance-suite/open-metadata-conformance-suite-server/src/main/java/org/odpi/openmetadata/conformance/tests/performance/search/TestRelationshipHistorySearch.java
@@ -126,7 +126,7 @@ public class TestRelationshipHistorySearch extends OpenMetadataPerformanceTestCa
                     null,
                     asOfTime,
                     null,
-                    SequencingOrder.GUID,
+                    null,
                     performanceWorkPad.getMaxSearchResults());
             long elapsedTime = (System.nanoTime() - start) / 1000000;
 
@@ -155,7 +155,7 @@ public class TestRelationshipHistorySearch extends OpenMetadataPerformanceTestCa
                         null,
                         asOfTime,
                         null,
-                        SequencingOrder.GUID,
+                        null,
                         performanceWorkPad.getMaxSearchResults());
                 elapsedTime = (System.nanoTime() - start) / 1000000;
                 if (results != null && !results.isEmpty()) {

--- a/open-metadata-conformance-suite/open-metadata-conformance-suite-server/src/main/java/org/odpi/openmetadata/conformance/tests/performance/search/TestRelationshipSearch.java
+++ b/open-metadata-conformance-suite/open-metadata-conformance-suite-server/src/main/java/org/odpi/openmetadata/conformance/tests/performance/search/TestRelationshipSearch.java
@@ -120,7 +120,7 @@ public class TestRelationshipSearch extends OpenMetadataPerformanceTestCase
                     null,
                     null,
                     null,
-                    SequencingOrder.GUID,
+                    null,
                     performanceWorkPad.getMaxSearchResults());
             long elapsedTime = (System.nanoTime() - start) / 1000000;
 
@@ -156,7 +156,7 @@ public class TestRelationshipSearch extends OpenMetadataPerformanceTestCase
                         null,
                         null,
                         null,
-                        SequencingOrder.GUID,
+                        null,
                         performanceWorkPad.getMaxSearchResults());
                 elapsedTime = (System.nanoTime() - start) / 1000000;
                 if (results != null && !results.isEmpty()) {


### PR DESCRIPTION
Removes result ordering from the performance test scenarios that run a `find...` for _all_ instances of metadata of a given type. This is to add an unsorted search performance result into the tests, since all other tests are already doing sorting based on some other criteria.

In addition, this change should also validate that a given repository still returns consistent pages of results even without a sequencing order being explicitly provided.