### PR TITLE
#5855 Fix chassis start failure caused by jackson dataformat version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ allprojects {
             implementation("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
             implementation("com.fasterxml.jackson.core:jackson-core:${jacksonVersion}")
             implementation("com.fasterxml.jackson.core:jackson-datatype-jsr310:${jacksonVersion}")
+            implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}")
             implementation("com.fasterxml:classmate:1.5.1")
             implementation("com.github.jsonld-java:jsonld-java:0.13.3")
             implementation("com.google.crypto.tink:tink:1.6.1")

--- a/open-metadata-implementation/server-chassis/server-chassis-spring/pom.xml
+++ b/open-metadata-implementation/server-chassis/server-chassis-spring/pom.xml
@@ -445,12 +445,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.dataformat</groupId>
-                    <artifactId>jackson-dataformat-yaml</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,13 @@
             </dependency>
 
             <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <scope>compile</scope>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <scope>compile</scope>


### PR DESCRIPTION

Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

<!-- SPDX-License-Identifier: CC-BY-4.0 -->
<!-- Copyright Contributors to the Egeria project. -->
# Description

* Removes exclusion of jackson dataformat library
* pins version (maven + gradle) to be consistent with other jackson libs & meeting min prereq levels of swagger & lineage

Fixes #5855

# How Has This Been Tested?

chassis launches cleanly. More complete tests will be done in notebook environment

# Any additional notes for reviewers?

May be impact elastic search if function not covered by FVTs or notebooks - though unlikely
