### PR TITLE
#5855 add publish to quay.io for release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 # Copyright Contributors to the ODPi Egeria project.
 name: "Release"
 
-# Trigger when a Release is created in github 
+# Trigger when a Release is created in github
 # - does not run on modification (may be just text)
 
 on:
@@ -12,8 +12,6 @@ on:
       - created
   # Also allow for manual invocation for testing
   workflow_dispatch:
-
-
 
 jobs:
   build:
@@ -25,15 +23,20 @@ jobs:
       # Prep for docker builds which are currently done as part of the maven build
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
+      - name: Login to container registry (Quay.io)
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_ACCESS_TOKEN }}
+      - name: Login to container registry (docker.io)
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          # Java 1.8 is used for final released build
           distribution: 'adopt'
           java-version: '11'
           # Publishing attributes for maven central (this step adds to setting.xml)
@@ -43,11 +46,30 @@ jobs:
           # Keys must be known to maven central - require broad publishing
           gpg-private-key: ${{ secrets.OSSRH_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
-      # Normal build (in future may also run reports (site))
-      - name: Build with Maven
+      # Normal build (in future may also run reports (site)) -
+      - name: Build with Maven and publish to oss.sonatype.org
         # See https://github.com/actions/toolkit/issues/231 requires parms using . to be quoted
-        run: 'mvn -B -DuseMavenCentral -Ddocker "-Ddocker.repo=odpi" "-Ddocker.registry=docker.io" "-Ddocker.images=core" clean deploy'        
-        # Needed for publishing -- note we push to a staging area, login to oss.sonatype.org to 
+        run: 'mvn -B -DuseMavenCentral clean deploy'
+        # Needed for publishing -- note we push to a staging area, login to oss.sonatype.org to
+        # verify (close) the repository & release
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
+      - name: Publish container images to quay.io
+        # See https://github.com/actions/toolkit/issues/231 requires parms using . to be quoted
+        run: 'cd open-metadata-resources/open-metadata-deployment/docker && mvn -B -DuseMavenCentral -Ddocker "-Ddocker.taglatest" "-Ddocker.repo=odpi" "-Ddocker.registry=quay.io" "-Ddocker.images=core" clean deploy'
+        # Needed for publishing -- note we push to a staging area, login to oss.sonatype.org to
+        # verify (close) the repository & release
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
+      # Push docker images to docker.io
+      - name: Publish container images to docker.io
+        # See https://github.com/actions/toolkit/issues/231 requires parms using . to be quoted
+        run: 'cd open-metadata-resources/open-metadata-deployment/docker && mvn -B -DuseMavenCentral -Ddocker "-Ddocker.taglatest" "-Ddocker.repo=odpi" "-Ddocker.registry=docker.io" "-Ddocker.images=core" clean deploy'
+        # Needed for publishing -- note we push to a staging area, login to oss.sonatype.org to
         # verify (close) the repository & release
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

<!-- SPDX-License-Identifier: CC-BY-4.0 -->
<!-- Copyright Contributors to the Egeria project. -->
# Description

- Adds publishing to quay.io to release pipeline
- this was accidentally omitted when the change was made to merges

Fixes #5855

# How Has This Been Tested?

tested with yamllint for syntax
full test can only be after merge (in fact, release...)

# Any additional notes for reviewers?

