### PR TITLE
Distinguish between security filtering of query results and explicit invalid access

### DIFF
--- a/open-metadata-implementation/adapters/open-connectors/metadata-security-connectors/open-metadata-access-security-connector/src/main/java/org/odpi/openmetadata/metadatasecurity/accessconnector/OpenMetadataAccessSecurityConnector.java
+++ b/open-metadata-implementation/adapters/open-connectors/metadata-security-connectors/open-metadata-access-security-connector/src/main/java/org/odpi/openmetadata/metadatasecurity/accessconnector/OpenMetadataAccessSecurityConnector.java
@@ -1338,6 +1338,7 @@ public class OpenMetadataAccessSecurityConnector extends OpenMetadataSecurityCon
      *
      * @param userId calling user
      * @param requestedEntity entity requested by the caller
+     * @param isExplicitGetRequest is this entity requested explicitly
      * @param repositoryHelper helper for OMRS objects
      * @param serviceName calling service
      * @param methodName calling method
@@ -1348,6 +1349,7 @@ public class OpenMetadataAccessSecurityConnector extends OpenMetadataSecurityCon
     @Override
     public void validateUserForElementRead(String               userId,
                                            EntityDetail         requestedEntity,
+                                           boolean              isExplicitGetRequest,
                                            OMRSRepositoryHelper repositoryHelper,
                                            String               serviceName,
                                            String               methodName) throws UserNotAuthorizedException,
@@ -1365,11 +1367,21 @@ public class OpenMetadataAccessSecurityConnector extends OpenMetadataSecurityCon
             return;
         }
 
-        throwUnauthorizedElementAccess(userId,
-                                       AccessOperation.READ.getName(),
-                                       requestedEntity.getGUID(),
-                                       requestedEntity.getType().getTypeDefName(),
-                                       methodName);
+        if (isExplicitGetRequest)
+        {
+            throwUnauthorizedElementAccess(userId,
+                                           AccessOperation.READ.getName(),
+                                           requestedEntity.getGUID(),
+                                           requestedEntity.getType().getTypeDefName(),
+                                           methodName);
+        }
+        else
+        {
+            throwFilteredElement(userId,
+                                 AccessOperation.READ.getName(),
+                                 requestedEntity.getGUID(),
+                                 methodName);
+        }
     }
 
 
@@ -1379,6 +1391,7 @@ public class OpenMetadataAccessSecurityConnector extends OpenMetadataSecurityCon
      * @param userId calling user
      * @param anchorEntity entity for the anchor (if extracted - may be null)
      * @param requestedEntity entity requested by the caller
+     * @param isExplicitGetRequest is this entity requested explicitly
      * @param repositoryHelper helper for OMRS objects
      * @param serviceName calling service
      * @param methodName calling method
@@ -1390,6 +1403,7 @@ public class OpenMetadataAccessSecurityConnector extends OpenMetadataSecurityCon
     public void validateUserForAnchorMemberRead(String               userId,
                                                 EntityDetail         anchorEntity,
                                                 EntityDetail         requestedEntity,
+                                                boolean              isExplicitGetRequest,
                                                 OMRSRepositoryHelper repositoryHelper,
                                                 String               serviceName,
                                                 String               methodName) throws UserNotAuthorizedException,
@@ -1412,11 +1426,21 @@ public class OpenMetadataAccessSecurityConnector extends OpenMetadataSecurityCon
                 return;
             }
 
-            throwUnauthorizedElementAccess(userId,
-                                           AccessOperation.READ.getName(),
-                                           requestedEntity.getGUID(),
-                                           requestedEntity.getType().getTypeDefName(),
-                                           methodName);
+            if (isExplicitGetRequest)
+            {
+                throwUnauthorizedElementAccess(userId,
+                                               AccessOperation.READ.getName(),
+                                               requestedEntity.getGUID(),
+                                               requestedEntity.getType().getTypeDefName(),
+                                               methodName);
+            }
+            else
+            {
+                throwFilteredElement(userId,
+                                     AccessOperation.READ.getName(),
+                                     requestedEntity.getGUID(),
+                                     methodName);
+            }
         }
         else
         {
@@ -2621,7 +2645,7 @@ public class OpenMetadataAccessSecurityConnector extends OpenMetadataSecurityCon
                 {
                     try
                     {
-                        validateUserForElementRead(userId, connection, repositoryHelper, serviceName, methodName);
+                        validateUserForElementRead(userId, connection, true, repositoryHelper, serviceName, methodName);
                         visibleConnections.add(connection);
                     }
                     catch (UserNotAuthorizedException error)

--- a/open-metadata-implementation/common-services/generic-handlers/src/main/java/org/odpi/openmetadata/commonservices/generichandlers/OpenMetadataAPIGenericHandler.java
+++ b/open-metadata-implementation/common-services/generic-handlers/src/main/java/org/odpi/openmetadata/commonservices/generichandlers/OpenMetadataAPIGenericHandler.java
@@ -138,8 +138,8 @@ public class OpenMetadataAPIGenericHandler<B> extends OpenMetadataAPIAnchorHandl
 
 
     /**
-     * Check that a retrieved entity is readable.  This is always the first check and include checks
-     * for private feedback, connection selection, asset zones and security tags on glossaries
+     * Check that a retrieved entity is readable.  This is always the first check and includes checks
+     * for private feedback, connection selection, and zones
      *
      * @param userId calling user
      * @param connectToEntity entity retrieved
@@ -166,6 +166,7 @@ public class OpenMetadataAPIGenericHandler<B> extends OpenMetadataAPIAnchorHandl
          */
         securityVerifier.validateUserForElementRead(userId,
                                                     connectToEntity,
+                                                    isExplicitGetRequest,
                                                     repositoryHelper,
                                                     serviceName,
                                                     methodName);
@@ -204,7 +205,7 @@ public class OpenMetadataAPIGenericHandler<B> extends OpenMetadataAPIAnchorHandl
      * @param connectToGUID       unique id for the object to connect the attachment to.
      * @param connectToGUIDParameterName  name of the parameter that passed the connectTo guid
      * @param connectToType       type of the connectToElement.
-     * @param isExplicitGetRequest Is this request an explicit get request for the asset or a find request.
+     * @param isExplicitGetRequest Is this request an explicit get request for the element or a find request.
      * @param isUpdate         is this an update request?
      * @param forLineage             the query is to support lineage retrieval
      * @param forDuplicateProcessing the query is for duplicate processing and so must not deduplicate
@@ -681,6 +682,7 @@ public class OpenMetadataAPIGenericHandler<B> extends OpenMetadataAPIAnchorHandl
                     securityVerifier.validateUserForAnchorMemberRead(userId,
                                                                      anchorEntity,
                                                                      connectToEntity,
+                                                                     isExplicitGetRequest,
                                                                      repositoryHelper,
                                                                      serviceName,
                                                                      methodName);

--- a/open-metadata-implementation/common-services/metadata-security/metadata-security-apis/src/main/java/org/odpi/openmetadata/metadatasecurity/OpenMetadataElementSecurity.java
+++ b/open-metadata-implementation/common-services/metadata-security/metadata-security-apis/src/main/java/org/odpi/openmetadata/metadatasecurity/OpenMetadataElementSecurity.java
@@ -54,6 +54,7 @@ public interface OpenMetadataElementSecurity
      *
      * @param userId calling user
      * @param requestedEntity entity requested by the caller
+     * @param isExplicitGetRequest is this entity requested explicitly
      * @param repositoryHelper helper for OMRS objects
      * @param serviceName calling service
      * @param methodName calling method
@@ -64,6 +65,7 @@ public interface OpenMetadataElementSecurity
      */
     void validateUserForElementRead(String               userId,
                                     EntityDetail         requestedEntity,
+                                    boolean              isExplicitGetRequest,
                                     OMRSRepositoryHelper repositoryHelper,
                                     String               serviceName,
                                     String               methodName) throws UserNotAuthorizedException,
@@ -307,6 +309,7 @@ public interface OpenMetadataElementSecurity
      * @param userId calling user
      * @param anchorEntity entity for the anchor (if extracted - may be null)
      * @param requestedEntity entity requested by the caller
+     * @param isExplicitGetRequest is this entity requested explicitly
      * @param repositoryHelper helper for OMRS objects
      * @param serviceName calling service
      * @param methodName calling method
@@ -316,6 +319,7 @@ public interface OpenMetadataElementSecurity
     void validateUserForAnchorMemberRead(String               userId,
                                          EntityDetail         anchorEntity,
                                          EntityDetail         requestedEntity,
+                                         boolean              isExplicitGetRequest,
                                          OMRSRepositoryHelper repositoryHelper,
                                          String               serviceName,
                                          String               methodName) throws UserNotAuthorizedException,

--- a/open-metadata-implementation/common-services/metadata-security/metadata-security-apis/src/main/java/org/odpi/openmetadata/metadatasecurity/ffdc/OpenMetadataSecurityAuditCode.java
+++ b/open-metadata-implementation/common-services/metadata-security/metadata-security-apis/src/main/java/org/odpi/openmetadata/metadatasecurity/ffdc/OpenMetadataSecurityAuditCode.java
@@ -190,13 +190,13 @@ public enum OpenMetadataSecurityAuditCode implements AuditLogMessageSet
                                         "  Take action to either change the security sessions or determine the reason for the unauthorized request."),
 
     /**
-     * OPEN-METADATA-SECURITY-0021 - User {0} is not authorized to issue operation {1} because the anchor is null
+     * OPEN-METADATA-SECURITY-0021 - User {0} is not authorized to access element {1} returned from a {2} operation; it has been filtered from the results
      */
-    NULL_ANCHOR("OPEN-METADATA-SECURITY-0021",
-                AuditLogRecordSeverityLevel.SECURITY,
-                "User {0} is not authorized to issue operation {1} because the element's anchor is null",
-                "The system cannot process a request from the user because the element is not correctly anchored.",
-                "The request fails with a UserNotAuthorizedException exception. Add the Anchors classification and re-run the request."),
+    FILTERED_ELEMENT("OPEN-METADATA-SECURITY-0021",
+                     AuditLogRecordSeverityLevel.INFO,
+                     "User {0} is not authorized to access element {1} returned from a {2} operation; it has been filtered from the results",
+                     "The system has filtered an element from the results because the user does not have the necessary permissions to access it.",
+                     "The element is filtered from the results."),
 
     /**
      * OPEN-METADATA-SECURITY-0022 - User {0} is not recognized

--- a/open-metadata-implementation/common-services/metadata-security/metadata-security-apis/src/main/java/org/odpi/openmetadata/metadatasecurity/ffdc/OpenMetadataSecurityErrorCode.java
+++ b/open-metadata-implementation/common-services/metadata-security/metadata-security-apis/src/main/java/org/odpi/openmetadata/metadatasecurity/ffdc/OpenMetadataSecurityErrorCode.java
@@ -239,12 +239,12 @@ public enum OpenMetadataSecurityErrorCode implements ExceptionMessageSet
                            "Investigate and correct the behaviour of the server security connector."),
 
     /**
-     * OMAG-SERVER-SECURITY-500-002 - User {0} is not authorized to issue operation {1} because the anchor is null
+     * OMAG-SERVER-SECURITY-500-002 - User {0} is not authorized to access element {1} returned from a {2} operation; it has been filtered from the results
      */
-    NULL_ANCHOR(500, "OMAG-SERVER-SECURITY-500-002",
-                "User {0} is not authorized to issue operation {1} on an element because the anchor is null",
-                "The system cannot process a request from the user because the element is not correctly anchored.",
-                "The request fails with a UserNotAuthorizedException exception. Add the anchor relationship of the glossary element to its glossary and corresponding Anchors classification.  When both are in place, re-run the request."),
+    FILTERED_ELEMENT(500, "OMAG-SERVER-SECURITY-500-002",
+                     "User {0} is not authorized to access element {1} returned from a {2} operation; it has been filtered from the results",
+                     "The system has filtered an element from the results because the user does not have the necessary permissions to access it.",
+                     "The element is filtered from the results."),
 
     ;
 

--- a/open-metadata-implementation/common-services/metadata-security/metadata-security-connectors/src/main/java/org/odpi/openmetadata/metadatasecurity/connectors/OpenMetadataSecurityConnector.java
+++ b/open-metadata-implementation/common-services/metadata-security/metadata-security-connectors/src/main/java/org/odpi/openmetadata/metadatasecurity/connectors/OpenMetadataSecurityConnector.java
@@ -525,13 +525,14 @@ public class OpenMetadataSecurityConnector extends ConnectorBase implements Audi
      *
      * @throws UserNotAuthorizedException the authorization check failed
      */
-    protected void throwMissingAnchor(String       userId,
-                                      String       operation,
-                                      String       methodName) throws UserNotAuthorizedException
+    protected void throwFilteredElement(String userId,
+                                        String operation,
+                                        String entityGUID,
+                                        String methodName) throws UserNotAuthorizedException
     {
-        logRecord(methodName, OpenMetadataSecurityAuditCode.NULL_ANCHOR.getMessageDefinition(userId, operation));
+        logRecord(methodName, OpenMetadataSecurityAuditCode.FILTERED_ELEMENT.getMessageDefinition(userId, entityGUID, operation));
 
-        throw new UserNotAuthorizedException(OpenMetadataSecurityErrorCode.NULL_ANCHOR.getMessageDefinition(userId, operation),
+        throw new UserNotAuthorizedException(OpenMetadataSecurityErrorCode.FILTERED_ELEMENT.getMessageDefinition(userId, entityGUID, operation),
                                              this.getClass().getName(),
                                              methodName,
                                              userId);
@@ -539,12 +540,13 @@ public class OpenMetadataSecurityConnector extends ConnectorBase implements Audi
 
 
     /**
-     * Write an audit log message and throw exception to record an unauthorized access.
+     * Write an audit log message and throw an exception to record an unauthorized access.
      *
-     * @param userId calling user
-     * @param operation of requested operation
-     * @param methodName calling method
-     *
+     * @param userId         calling user
+     * @param operation      of requested operation
+     * @param entityGUID     unique identifier of the entity
+     * @param entityTypeName name of the entity type
+     * @param methodName     calling method
      * @throws UserNotAuthorizedException the authorization check failed
      */
     protected void throwUnauthorizedElementAccess(String userId,

--- a/open-metadata-implementation/common-services/metadata-security/metadata-security-server/src/main/java/org/odpi/openmetadata/metadatasecurity/server/OpenMetadataServerSecurityVerifier.java
+++ b/open-metadata-implementation/common-services/metadata-security/metadata-security-server/src/main/java/org/odpi/openmetadata/metadatasecurity/server/OpenMetadataServerSecurityVerifier.java
@@ -471,6 +471,7 @@ public class OpenMetadataServerSecurityVerifier implements OpenMetadataRepositor
      *
      * @param userId calling user
      * @param requestedEntity entity requested by the caller
+     * @param isExplicitGetRequest is this entity requested explicitly
      * @param repositoryHelper helper for OMRS objects
      * @param serviceName calling service
      * @param methodName calling method
@@ -481,6 +482,7 @@ public class OpenMetadataServerSecurityVerifier implements OpenMetadataRepositor
     @Override
     public void validateUserForElementRead(String               userId,
                                            EntityDetail         requestedEntity,
+                                           boolean              isExplicitGetRequest,
                                            OMRSRepositoryHelper repositoryHelper,
                                            String               serviceName,
                                            String               methodName) throws UserNotAuthorizedException,
@@ -489,7 +491,7 @@ public class OpenMetadataServerSecurityVerifier implements OpenMetadataRepositor
     {
         if (elementSecurityConnector != null)
         {
-            elementSecurityConnector.validateUserForElementRead(userId, requestedEntity, repositoryHelper, serviceName, methodName);
+            elementSecurityConnector.validateUserForElementRead(userId, requestedEntity, isExplicitGetRequest, repositoryHelper, serviceName, methodName);
         }
     }
 
@@ -500,6 +502,7 @@ public class OpenMetadataServerSecurityVerifier implements OpenMetadataRepositor
      * @param userId calling user
      * @param anchorEntity entity for the anchor (if extracted - may be null)
      * @param requestedEntity entity requested by the caller
+     * @param isExplicitGetRequest is this entity requested explicitly
      * @param repositoryHelper helper for OMRS objects
      * @param serviceName calling service
      * @param methodName calling method
@@ -511,6 +514,7 @@ public class OpenMetadataServerSecurityVerifier implements OpenMetadataRepositor
     public void validateUserForAnchorMemberRead(String               userId,
                                                 EntityDetail         anchorEntity,
                                                 EntityDetail         requestedEntity,
+                                                boolean              isExplicitGetRequest,
                                                 OMRSRepositoryHelper repositoryHelper,
                                                 String               serviceName,
                                                 String               methodName) throws UserNotAuthorizedException,
@@ -519,7 +523,7 @@ public class OpenMetadataServerSecurityVerifier implements OpenMetadataRepositor
     {
         if (elementSecurityConnector != null)
         {
-            elementSecurityConnector.validateUserForAnchorMemberRead(userId, anchorEntity, requestedEntity, repositoryHelper, serviceName, methodName);
+            elementSecurityConnector.validateUserForAnchorMemberRead(userId, anchorEntity, requestedEntity, isExplicitGetRequest, repositoryHelper, serviceName, methodName);
         }
     }
 

--- a/open-metadata-implementation/view-services/security-officer/Egeria-coco-audit-users.http
+++ b/open-metadata-implementation/view-services/security-officer/Egeria-coco-audit-users.http
@@ -134,6 +134,21 @@ POST {{baseURL}}/servers/{{viewServer}}/api/open-metadata/actor-manager/user-ide
 Authorization: Bearer {{garyToken}}
 Content-Type: application/json
 
+###
+# @name getUserIdentityByGUID (gary)
+# Return the properties of a specific user identity.
+#
+# @param userIdentityGUID    unique identifier of the required element
+# Request body provides string to find in the properties
+#
+# Returns list of matching metadata elements or
+#  InvalidParameterException  one of the parameters is invalid
+#  UserNotAuthorizedException the user is not authorized to issue this request
+#  PropertyServerException    a problem reported in the open metadata server(s)
+#
+POST {{baseURL}}/servers/{{viewServer}}/api/open-metadata/actor-manager/user-identities/1d1d3d60-3808-4bda-94f0-c3792a53bed6/retrieve
+Authorization: Bearer {{garyToken}}
+Content-Type: application/json
 
 
 ###
@@ -152,7 +167,21 @@ Authorization: Bearer {{ivorToken}}
 Content-Type: application/json
 
 
-
+###
+# @name getUserIdentityByGUID (ivor)
+# Return the properties of a specific user identity.
+#
+# @param userIdentityGUID    unique identifier of the required element
+# Request body provides string to find in the properties
+#
+# Returns list of matching metadata elements or
+#  InvalidParameterException  one of the parameters is invalid
+#  UserNotAuthorizedException the user is not authorized to issue this request
+#  PropertyServerException    a problem reported in the open metadata server(s)
+#
+POST {{baseURL}}/servers/{{viewServer}}/api/open-metadata/actor-manager/user-identities/1d1d3d60-3808-4bda-94f0-c3792a53bed6/retrieve
+Authorization: Bearer {{ivorToken}}
+Content-Type: application/json
 
 ###
 # ========================================================================================
@@ -160,212 +189,34 @@ Content-Type: application/json
 #
 
 ###
-# @name: getUserAccount
-# Return the user account object for the requested user from the platform metadata security connector.  Null is returned if no platform security or user account has been set up.
-# The user requires operator permission for the platform unless it is their own user account they are retrieving.
-#
-# @param serverName  name of called server
-# @param platformGUID unique identifier of the platform
-# @param accountUserId    user id of the account
-# @return user account response
-#
-## Gary can see Callie's account
-GET {{baseURL}}/servers/{{viewServer}}/api/open-metadata/security-officer/platforms/{{omagServerPlatformGUID}}/user-accounts/calliequartile
-Authorization: Bearer {{garyToken}}
-
-###
-## Callie can see her own account
-GET {{baseURL}}/servers/{{viewServer}}/api/open-metadata/security-officer/platforms/{{omagServerPlatformGUID}}/user-accounts/calliequartile
-Authorization: Bearer {{callieToken}}
-
-###
-## Callie can not see Gary's account
-GET {{baseURL}}/servers/{{viewServer}}/api/open-metadata/security-officer/platforms/{{omagServerPlatformGUID}}/user-accounts/garygeeke
-Authorization: Bearer {{callieToken}}
-
-###
-## Gary can see his account
-GET {{baseURL}}/servers/{{viewServer}}/api/open-metadata/security-officer/platforms/{{omagServerPlatformGUID}}/user-accounts/garygeeke
-Authorization: Bearer {{garyToken}}
-
-###
-## Gary can see his account
-GET {{baseURL}}/servers/{{viewServer}}/api/open-metadata/security-officer/platforms/{{omagServerPlatformGUID}}/user-accounts/garygeeke
-Authorization: Bearer {{garyToken}}
-
-###
-# ========================================================================================
-# Setting up new user account for Freddie Mercury
-#
-###
-
-@accountUserId=freddiemercury
-
-###
-## If the account does not exist, nothing is returned.
-GET {{baseURL}}/servers/{{viewServer}}/api/open-metadata/security-officer/platforms/{{omagServerPlatformGUID}}/user-accounts/{{accountUserId}}
-Authorization: Bearer {{garyToken}}
-
-###
-
-# @name: setUserAccount
-# Set up or update a user account in the platform metadata security connector
-# The user requires operator permission for the platform.
-#
-# @param serverName  name of called server
-# @param platformGUID unique identifier of the platform
-# @param requestBody requestBody used to create and configure the connector that performs platform security
-# @return void response
-#/
-POST {{baseURL}}/servers/{{viewServer}}/api/open-metadata/security-officer/platforms/{{omagServerPlatformGUID}}/user-accounts
-Authorization: Bearer {{garyToken}}
+# @name findGovernanceDefinitions
+# Retrieve the list of governance definition metadata elements that contain the search string.
+POST {{baseURL}}/servers/{{viewServer}}/api/open-metadata/governance-officer/governance-definitions/by-search-string
+Authorization: Bearer {{ivorToken}}
 Content-Type: application/json
 
 {
-  "class" : "UserAccountRequestBody",
-  "userAccount": {
-    "class" : "OpenMetadataUserAccount",
-    "userId": "{{accountUserId}}",
-    "userName": "Freddie Mercury",
-    "userAccountType": "EXTERNAL",
-    "employeeNumber": "",
-    "employeeType": "",
-    "givenName": "Freddie",
-    "surname": "Mercury",
-    "email": "freddiemercury@queen.com",
-    "securityRoles": ["serverOperator", "serverInvestigator"],
-    "userAccountStatus": "CREDENTIALS_EXPIRED",
-    "secrets": {
-      "clearPassword" : "itsakindofmagic"
-    }
-  }
+  "class" : "SearchStringRequestBody",
+  "metadataElementTypeName": "ExceptionType"
 }
 
 
-###
-
-# @name Token (log in as Freddie Mercury, our new user, without new password - it fails)
-POST {{baseURL}}/api/token
-Content-Type: application/json
-
-{
-  "userId" : "{{accountUserId}}",
-  "password" : "itsakindofmagic"
-}
-
-> {% client.global.set("freddieToken", response.body); %}
-
-###
-
-# @name Token (log in as Freddie Mercury, our new user, with new password)
-POST {{baseURL}}/api/token
-Content-Type: application/json
-
-{
-  "userId" : "{{accountUserId}}",
-  "password" : "itsakindofmagic",
-  "newPassword": "magic, magic"
-}
-
-> {% client.global.set("freddieToken", response.body); %}
-
-
-###
-## Show that freddie can see his account - and his password is encrypted.
-GET {{baseURL}}/servers/{{viewServer}}/api/open-metadata/security-officer/platforms/{{omagServerPlatformGUID}}/user-accounts/{{accountUserId}}
-Authorization: Bearer {{freddieToken}}
-
-###
-# @name Token (log in as Freddie Mercury, our new user, with password)
-POST {{baseURL}}/api/token
-Content-Type: application/json
-
-{
-  "userId" : "{{accountUserId}}",
-  "password" : "magic, magic"
-}
-
-> {% client.global.set("freddieToken", response.body); %}
-
-###
-# @name getPlatformReport (freddie)
-# Returns details about the running platform.
-
-GET {{baseURL}}/servers/{{viewServer}}/api/open-metadata/runtime-manager/platforms/{{omagServerPlatformGUID}}/report
-Authorization: Bearer {{freddieToken}}
-Content-Type: application/json
-
-###
-# @name Get Freddie's Profile (none returned)
-# Return the profile for Freddie.
-POST {{baseURL}}/servers/{{viewServer}}/api/open-metadata/my-profile
-Authorization: Bearer {{freddieToken}}
-Content-Type: application/json
-
-
-###
-# @name Add Freddie's Profile
-POST {{baseURL}}/servers/{{viewServer}}/api/open-metadata/my-profile/new
-Authorization: Bearer {{freddieToken}}
-Content-Type: application/json
-
-{
-  "class" : "NewElementRequestBody",
-  "isOwnAnchor": true,
-  "properties": {
-    "class" : "PersonProperties",
-    "qualifiedName": "PersonProperties::Freddie Mercury",
-    "displayName": "Freddie Mercury",
-    "courtesyTitle" : "Mr",
-    "initials" : "F",
-    "givenNames" : "Freddie",
-    "surname" : "Mercury",
-    "fullName" : "Mr Freddie Mercury",
-    "pronouns" : "He/Him/His",
-    "jobTitle" : "Lead singer for Queen",
-    "preferredLanguage" : "English",
-    "residentCountry" : "UK",
-    "timeZone" : "GMT",
-    "description": "Beloved singer and song-writer."
-  }
-}
-
-
-###
-# @name Get Freddie's Profile
-# Return the profile for Freddie.
-POST {{baseURL}}/servers/{{viewServer}}/api/open-metadata/my-profile
-Authorization: Bearer {{freddieToken}}
-Content-Type: application/json
 
 
 ###
 # ========================================================================================
-# Can Callie update her own User Account?   She attempts to give herself admin privileges
+# Retrieve governance zone
 #
+
 ###
-POST {{baseURL}}/servers/{{viewServer}}/api/open-metadata/security-officer/platforms/{{omagServerPlatformGUID}}/user-accounts
-Authorization: Bearer {{callieToken}}
+# @name findGovernanceDefinitions
+# Retrieve the list of governance definition metadata elements that contain the search string.
+POST {{baseURL}}/servers/{{viewServer}}/api/open-metadata/governance-officer/governance-definitions/by-search-string
+Authorization: Bearer {{ivorToken}}
 Content-Type: application/json
 
 {
-  "class": "UserAccountResponse",
-  "requestId": "a30a2090-cf6f-4d9a-8b5c-633f88707763",
-  "relatedHTTPCode": 200,
-  "userAccount": {
-    "userName": "Callie Quartile",
-    "securityRoles": [
-      "serverAdministrator",
-      "dataScientist",
-      "clinicalTrials",
-      "openMetadataMember"
-    ],
-    "userAccountStatus": "AVAILABLE",
-    "secrets": {
-      "clearPassword": "secret"
-    },
-    "userId": "calliequartile"
-  }
+  "class" : "SearchStringRequestBody",
+  "metadataElementTypeName": "GovernanceZone"
 }
-
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

## Description

This PR changes the error handling when the security connector detects a user cannot access an element that has been retrieved from the repository.

* if the element was extracted as a result of a query, then the element is filtered out and an informational message is written to the audit log
* if a element was explicitly retrieved (eg getXXXByGUID) then a UserNotAuthorizedException is raised and a security error is written to the audit log.

This means the security team can focus on real cases of invalid access and the metadata team are still warned that elements are being filtered by security.  Here are exampels of the two type of audit log message...

```
Wed Apr 15 15:45:08 BST 2026 active-metadata-store Information OPEN-METADATA-SECURITY-0021 User garygeeke is not authorized to access element 1d1d3d60-3808-4bda-94f0-c3792a53bed6 returned from a Read operation; it has been filtered from the results


Wed Apr 15 15:49:22 BST 2026 active-metadata-store Security OPEN-METADATA-SECURITY-0020 User garygeeke is not authorized to issue operation Read on UserIdentity element 1d1d3d60-3808-4bda-94f0-c3792a53bed6
```

## Related Issue(s)

None

## Testing

Using `coco-audit-users.http`

## Release Notes & Documentation

None

## Additional notes

None

