### PR TITLE
Dependabot triage - by Claude Code

### DIFF
--- a/.github/workflows/codeql-v5.yml
+++ b/.github/workflows/codeql-v5.yml
@@ -29,16 +29,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5.0.0
-      - uses: gradle/wrapper-validation-action@v2
+        uses: actions/checkout@v7.0.1
+      - uses: gradle/wrapper-validation-action@v3
       - name: Setup Java JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.30.9
+        uses: github/codeql-action/init@v4.37.3
         with:
           languages: java
           queries: security-and-quality
@@ -51,6 +51,6 @@ jobs:
           cache-disabled: true
           arguments: -x javadoc -x test build -PskipOpenTypesFVT
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.30.9
+        uses: github/codeql-action/analyze@v4.37.3
         with:
           ram: 4096

--- a/.github/workflows/codeql-v6.yml
+++ b/.github/workflows/codeql-v6.yml
@@ -29,16 +29,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
-      - uses: gradle/wrapper-validation-action@v2
+        uses: actions/checkout@v7.0.1
+      - uses: gradle/wrapper-validation-action@v3
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.30.9
+        uses: github/codeql-action/init@v4.37.3
         with:
           languages: java
           queries: security-and-quality
@@ -51,6 +51,6 @@ jobs:
           cache-disabled: true
           arguments: -x javadoc -x test build -PskipOpenTypesFVT
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.30.9
+        uses: github/codeql-action/analyze@v4.37.3
         with:
           ram: 4096

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.repository,'odpi/')
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v7.0.1
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2.6.1
+        uses: lycheeverse/lychee-action@v2.9.0
         with:
           # Can switch to true once we run clean
           fail: false

--- a/.github/workflows/merge-v5.yml
+++ b/.github/workflows/merge-v5.yml
@@ -22,11 +22,11 @@ jobs:
     name: "Merge v5"
     if: startsWith(github.repository,'odpi/')
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v7.0.1
         name: Checkout source
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/wrapper-validation-action@v3
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/merge-v6.yml
+++ b/.github/workflows/merge-v6.yml
@@ -22,11 +22,11 @@ jobs:
     name: "Merge v6"
     if: startsWith(github.repository,'odpi/')
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7.0.1
         name: Checkout source
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/wrapper-validation-action@v3
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/pr-v5.yml
+++ b/.github/workflows/pr-v5.yml
@@ -16,10 +16,10 @@ jobs:
     name: "Verify PR v5"
     if: startsWith(github.repository,'odpi/')
     steps:
-      - uses: actions/checkout@v5.0.0
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: actions/checkout@v7.0.1
+      - uses: gradle/wrapper-validation-action@v3
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/pr-v6.yml
+++ b/.github/workflows/pr-v6.yml
@@ -16,10 +16,10 @@ jobs:
     name: "Verify PR v6"
     if: startsWith(github.repository,'odpi/')
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: actions/checkout@v7.0.1
+      - uses: gradle/wrapper-validation-action@v3
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/release-v5.yml
+++ b/.github/workflows/release-v5.yml
@@ -24,9 +24,9 @@ jobs:
     name: "Release"
     if: startsWith(github.repository,'odpi/')
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v7.0.1
         name: Checkout source
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/wrapper-validation-action@v3
       # Prep for docker builds
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -42,7 +42,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/release-v6.yml
+++ b/.github/workflows/release-v6.yml
@@ -24,9 +24,9 @@ jobs:
     name: "Release"
     if: startsWith(github.repository,'odpi/')
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7.0.1
         name: Checkout source
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/wrapper-validation-action@v3
       # Prep for docker builds
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -42,7 +42,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5.0.0  # tag=v3.0.0
+        uses: actions/checkout@v7.0.1  # tag=v3.0.0
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # tag=v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc  # tag=v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -62,6 +62,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4.30.9  # tag=v1.0.26
+        uses: github/codeql-action/upload-sarif@v4.37.3  # tag=v1.0.26
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: check stale issues and prs
         if: startsWith(github.repository,'odpi/')
-        uses: actions/stale@v10
+        uses: actions/stale@v11
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -55,7 +55,7 @@ ext {
     hdrhistogramVersion = '2.2.2'
     hibernatevalidatorVersion = '8.0.5.Final'
     jacksonVersion = '2.15.0'
-    jacksonDatabindVersion = '2.20.0'
+    jacksonDatabindVersion = '2.22.1'
 //    TODO: jacksonDatabindVersion = '2.18.2' monday - failed at runtime
     jacksonaslVersion = '1.9.14-atlassian-6'
     jakartaannotationVersion = '2.1.1'
@@ -64,7 +64,7 @@ ext {
     janusVersion = '0.6.4'
     javassistVersion = '3.29.2-GA'
     jaxbVersion = '2.3.1'
-    jenaVersion = '5.5.0'
+    jenaVersion = '6.1.0'
     jodatimeVersion = '2.14.3'
     jsonldVersion = '0.13.6'
     junitVersion = '4.13.2'
@@ -77,7 +77,7 @@ ext {
     kafkaVersion = '4.3.1'
     lang3Version = '3.19.0'
 //    TODO: logbackVersion = '1.5.8' build break
-    logbackVersion = '1.5.20'
+    logbackVersion = '1.6.2'
     lettuceVersion = '7.6.0.RELEASE'
     //      TODO: Lucene Version 9 now available but changed the naming of Codec files and so does not work with XTDB
     luceneVersion = '8.11.3'
@@ -122,7 +122,7 @@ ext {
     protobufVersion = '3.25.9' //ok working
     log4jVersion = '2.26.1'
 //    TODO: log4jVersion = '2.24.3' Monday - doesn't build'
-    jacksonjdk8Version = '2.20.0'
+    jacksonjdk8Version = '2.22.1'
 //    TODO: jacksonjdk8Version = '2.18.2'monday - failed at runtime
     springdocStarterVersion = '2.2.0'
     jacocoVersion = '0.8.8'

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -27,16 +27,16 @@ ext {
     xtdbVersion = '1.24.4'
     clojureVersion = '1.12.0'
 
-    classgraphVersion = '4.8.179'
+    classgraphVersion = '4.8.192'
     classmateVersion = '1.5.1'
     collections4Version = '4.4'
     // TODO: Version 1.17.0 breaks XTDB because of a change in lucene's library names
-    commonscodecVersion = '1.16.0'
-    commonsconfiguration2Version = '2.10.1'
+    commonscodecVersion = '1.22.0'
+    commonsconfiguration2Version = '2.15.1'
     commonsconfigurationVersion = '1.10'
 
-    commonsioVersion = '2.18.0'
-    commonsloggingVersion = '1.3.2'
+    commonsioVersion = '2.22.0'
+    commonsloggingVersion = '1.4.0'
     // TODO: Version 1.12.0 breaks XTDB because of a change in lucene's library names
     commonstextVersion = '1.11.0'
 
@@ -53,7 +53,7 @@ ext {
     guavaVersion = '33.3.1-jre'
     hamcrestVersion = '3.0'
     hdrhistogramVersion = '2.2.2'
-    hibernatevalidatorVersion = '8.0.1.Final'
+    hibernatevalidatorVersion = '8.0.5.Final'
     jacksonVersion = '2.15.0'
     jacksonDatabindVersion = '2.20.0'
 //    TODO: jacksonDatabindVersion = '2.18.2' monday - failed at runtime
@@ -65,37 +65,37 @@ ext {
     javassistVersion = '3.29.2-GA'
     jaxbVersion = '2.3.1'
     jenaVersion = '5.5.0'
-    jodatimeVersion = '2.13.0'
+    jodatimeVersion = '2.14.3'
     jsonldVersion = '0.13.6'
     junitVersion = '4.13.2'
     junitjupiterVersion = '5.11.3'
     junitplatformVersion = '1.9.2'
-    jwtVersion = '10.5'
+    jwtVersion = '10.9.1'
     jwtApiVersion = '0.13.0'
     jwtImplVersion = '0.11.5'
     jwtJacksonVersion = '0.11.5'
-    kafkaVersion = '4.1.0'
+    kafkaVersion = '4.3.1'
     lang3Version = '3.19.0'
 //    TODO: logbackVersion = '1.5.8' build break
     logbackVersion = '1.5.20'
-    lettuceVersion = '7.0.0.RELEASE'
+    lettuceVersion = '7.6.0.RELEASE'
     //      TODO: Lucene Version 9 now available but changed the naming of Codec files and so does not work with XTDB
     luceneVersion = '8.11.3'
-    openlineageVersion = '1.37.0'
-    ossVersion = '4.16.0'
+    openlineageVersion = '1.52.0'
+    ossVersion = '4.17.0'
     //      TODO: Held as data engine breaks
     mockitoVersion = '4.11.0'
     mssqlVersion = '12.8.1.jre11'
     oracleJdbcVersion = '23.5.0.24.07'
     plexusVersion = '4.0.2'
-    postgresVersion = '42.7.8' // already there
+    postgresVersion = '42.7.13' // already there
     hikariVersion = '5.1.0'
-    nettyVersion = '4.2.7.Final'
-    prometheusVersion = '1.15.5'
+    nettyVersion = '4.2.17.Final'
+    prometheusVersion = '1.17.0'
     quartzVersion = '2.5.0'
     // TODO: May be able to remove as moving to jakarta servlet
     servletVersion = '4.0.1'
-    jakartaServletVersion = '6.0.0'
+    jakartaServletVersion = '6.1.0'
     sleepycatVersion = '18.3.12'
     slf4jVersion = '2.0.6'
     snappyVersion = '1.1.10.7'
@@ -103,24 +103,24 @@ ext {
     // This must be kept in step with the version of the springboot plugin in settings.gradle
     springbootVersion = '3.1.4'
 
-    spotbugsVersion = '4.9.8'
+    spotbugsVersion = '4.10.3'
     springdataVersion = '3.0.3'
     springldapVersion = '3.0.1'
     springsecurityVersion = '6.1.4'
     springsecurityJwtVersion = '1.1.1.RELEASE'
     testngVersion = '7.10.2'
-    swaggerVersion = '2.2.39'
+    swaggerVersion = '2.2.52'
     springwebVersion = '6.0.6'
     tinkVersion = '1.15.0'
     tomcatVersion = '10.1.13'
     validationVersion = '2.0.1.Final'
-    gsonVersion = '2.11.0'
-    antVersion = '1.10.15'
-     jnrVersion = '3.1.20'
+    gsonVersion = '2.14.0'
+    antVersion = '1.10.17'
+     jnrVersion = '3.2.1'
     //  TODO: cassandraVersion 5.0.1 and 5.0.2 don't work
     cassandraVersion = '4.1.5'
-    protobufVersion = '3.25.5' //ok working
-    log4jVersion = '2.24.1'
+    protobufVersion = '3.25.9' //ok working
+    log4jVersion = '2.26.1'
 //    TODO: log4jVersion = '2.24.3' Monday - doesn't build'
     jacksonjdk8Version = '2.20.0'
 //    TODO: jacksonjdk8Version = '2.18.2'monday - failed at runtime
@@ -296,7 +296,7 @@ dependencies {
         //TODO: Remove dependency line below in case the new parent library is updated and pulls good version.
         api("com.beust:jcommander:1.82")
         api("org.antlr:antlr4:4.13.1")
-        api("org.apache.ivy:ivy:2.5.2")
+        api("org.apache.ivy:ivy:2.6.0")
 
         // XTDB Additions
      //   api("com.xtdb:xtdb-core:${xtdbVersion}")


### PR DESCRIPTION
I worked through all 39 dependabot PRs (skipping the Spring group as you asked). Everything is on branch `dependabot-triage`, in two commits.

## Adopt now — 34 PRs, verified green

Build ✅ · BVT 5/5 ✅ · query-fvt 22/22 ✅

**GitHub Actions (7)** — no build impact:
9184 setup-java→5.6.0 · 9180 stale→11 · 9178 codeql-action→4.37.3 · 9173 scorecard-action→2.4.4 · 9171 checkout→7.0.1 · 9170 lychee-action→2.9.0 · 9083 wrapper-validation-action→3

**BOM minor/patch (24)**:
9188 ivy · 9187 classgraph · 9186 postgresql · 9185 joda-time · 9181 hibernate-validator · 9179 log4j · 9177 openlineage · 9175 spotbugs · 9174 netty · 9172 jakarta.servlet · 9147 jnr-posix · 9145 micrometer · 9144 kafka · 9141 swagger · 9137 commons-logging · 9094 nimbus-jose-jwt · 9090 lettuce · 9086 commons-configuration2 · 9065 gson · 9060 ant · 9057 cassandra-driver · 9053 commons-codec · 9047 commons-io · 9025 protobuf

**Major bumps that turned out clean (3)**:
- **8883 jackson** 2.20.0→2.22.1 — I checked the resolved graph: `jackson-bom` pulls core, annotations, jsr310, yaml and jdk8 up to 2.22.x too, so the `jacksonVersion = '2.15.0'` line causes no skew. That line is now effectively inert and could be tidied separately.
- **9182 logback** 1.5.20→1.6.2 — resolves correctly, exercised through the platform startup in query-fvt.
- **9091 jena** 5.5.0→6.1.0 — Egeria only touches `org.apache.jena.rdf.model`, stable across the major.

The stale hold-back comments near commons-codec/commons-text ("breaks XTDB") are obsolete — XTDB isn't in `settings.gradle` any more.

## Do not adopt

- **9063 freefair aggregate-javadoc 6.6.3→9.5.0** — a silent regression, and the existing "problem when upgraded to 9.0.0" comment is right. On 9.5.0 the plugin warns "should not be used on a java project" and simply **doesn't register the `aggregateJavadoc` task**; the build still goes green, but `merge-v5.yml`/`merge-v6.yml` run `arguments: aggregateJavadoc` and would break. Needs the aggregation moved to a non-java subproject.

## Blocked on a Gradle 9 migration

- **9183 dependency-analysis 1.32.0→3.18.0** — plugin requires Gradle 8.11.1+, we're on 8.1.1.
- **9176 junit-jupiter 5.11.3→6.1.3** — compiles fine, then BVT dies at discovery: *"OutputDirectoryCreator not available; probably due to unaligned versions of the junit-platform-engine and junit-platform-launcher jars"*. Jupiter 6 needs Platform 2.x; Gradle 8.1.1 injects its own 1.9.x launcher.
- **9149 gradle-wrapper 8.1.1→9.6.1** — I took this as far as it would go to size it. Two trivial fixes (a stale `configuration-encrypted-file-store-connector` include that no longer exists on disk; `url = uri(...)` in `settings.gradle`), then the abandoned `johnrengelman/shadow` 8.1.1 fails to apply. Migrating to `com.gradleup.shadow` 9.2.2 across 32 files got further, then hit `mainClassName` removal on `ShadowJar` across **31 modules** — with Gradle-10 deprecations still flagged behind that. This is a project in its own right, not a minimal change. All of it is reverted; the branch is back on Gradle 8.1.1.

Worth noting these three unblock as a set, so the Gradle upgrade is the single highest-leverage piece of work here.

