### PR TITLE
Handle delete method for relationships

### DIFF
--- a/open-metadata-implementation/access-services/omf-metadata-management/omf-metadata-server/src/main/java/org/odpi/openmetadata/frameworkservices/omf/server/OpenMetadataStoreRESTServices.java
+++ b/open-metadata-implementation/access-services/omf-metadata-management/omf-metadata-server/src/main/java/org/odpi/openmetadata/frameworkservices/omf/server/OpenMetadataStoreRESTServices.java
@@ -3679,7 +3679,9 @@ public class OpenMetadataStoreRESTServices
 
                 DeleteMethod deleteMethod = requestBody.getDeleteMethod();
 
-                if (deleteMethod == DeleteMethod.SOFT_DELETE)
+                if ((deleteMethod == DeleteMethod.SOFT_DELETE) ||
+                    (deleteMethod == DeleteMethod.LOOK_FOR_LINEAGE) ||
+                    (deleteMethod == DeleteMethod.ARCHIVE))
                 {
                     handler.deleteRelationshipInStore(userId,
                                                       requestBody.getExternalSourceGUID(),

--- a/open-metadata-implementation/frameworks/open-metadata-framework/src/main/java/org/odpi/openmetadata/frameworks/openmetadata/enums/DeleteMethod.java
+++ b/open-metadata-implementation/frameworks/open-metadata-framework/src/main/java/org/odpi/openmetadata/frameworks/openmetadata/enums/DeleteMethod.java
@@ -64,7 +64,7 @@ public enum DeleteMethod implements OpenMetadataEnum
 
     private final String descriptionGUID;
 
-    private final boolean        isDefault;
+    private final boolean isDefault;
 
 
     /**
@@ -82,11 +82,11 @@ public enum DeleteMethod implements OpenMetadataEnum
                  String  description,
                  boolean isDefault)
     {
-        this.ordinal = ordinal;
+        this.ordinal         = ordinal;
         this.name            = name;
         this.descriptionGUID = descriptionGUID;
         this.description     = description;
-        this.isDefault = isDefault;
+        this.isDefault       = isDefault;
     }
 
 

--- a/open-metadata-implementation/view-services/solution-architect/solution-architect-server/src/main/java/org/odpi/openmetadata/viewservices/solutionarchitect/server/SolutionArchitectRESTServices.java
+++ b/open-metadata-implementation/view-services/solution-architect/solution-architect-server/src/main/java/org/odpi/openmetadata/viewservices/solutionarchitect/server/SolutionArchitectRESTServices.java
@@ -260,7 +260,6 @@ public class SolutionArchitectRESTServices extends TokenController
 
             if (requestBody != null)
             {
-
                 if (requestBody.getProperties() instanceof InformationSupplyChainLinkProperties properties)
                 {
                     handler.linkPeersInInformationSupplyChain(userId,
@@ -1988,20 +1987,31 @@ public class SolutionArchitectRESTServices extends TokenController
 
             auditLog = instanceHandler.getAuditLog(userId, serverName, methodName);
 
-            DesignPatternHandler handler = instanceHandler.getDesignPatternHandler(userId, serverName, methodName);
-
-            DesignPatternProperties properties = null;
-
-            if (requestBody.getProperties() instanceof DesignPatternProperties designPatternProperties)
+            if (requestBody != null)
             {
-                properties = designPatternProperties;
-            }
+                DesignPatternHandler handler = instanceHandler.getDesignPatternHandler(userId, serverName, methodName);
 
-            response.setGUID(handler.createDesignPattern(userId,
-                                                         requestBody,
-                                                         requestBody.getInitialClassifications(),
-                                                         properties,
-                                                         requestBody.getParentRelationshipProperties()));
+                DesignPatternProperties properties = null;
+
+                if (requestBody.getProperties() instanceof DesignPatternProperties designPatternProperties)
+                {
+                    properties = designPatternProperties;
+
+                    response.setGUID(handler.createDesignPattern(userId,
+                                                                 requestBody,
+                                                                 requestBody.getInitialClassifications(),
+                                                                 properties,
+                                                                 requestBody.getParentRelationshipProperties()));
+                }
+                else
+                {
+                    restExceptionHandler.handleInvalidPropertiesObject(InformationSupplyChainProperties.class.getName(), methodName);
+                }
+            }
+            else
+            {
+                restExceptionHandler.handleNoRequestBody(userId, methodName, serverName);
+            }
         }
         catch (Throwable error)
         {
@@ -2042,15 +2052,22 @@ public class SolutionArchitectRESTServices extends TokenController
 
             auditLog = instanceHandler.getAuditLog(userId, serverName, methodName);
 
-            DesignPatternHandler handler = instanceHandler.getDesignPatternHandler(userId, serverName, methodName);
+            if (requestBody != null)
+            {
+                DesignPatternHandler handler = instanceHandler.getDesignPatternHandler(userId, serverName, methodName);
 
-            response.setGUID(handler.createDesignPatternFromTemplate(userId,
-                                                                     requestBody,
-                                                                     requestBody.getTemplateGUID(),
-                                                                     requestBody.getReplacementProperties(),
-                                                                     requestBody.getReplacementClassifications(),
-                                                                     requestBody.getPlaceholderPropertyValues(),
-                                                                     requestBody.getParentRelationshipProperties()));
+                response.setGUID(handler.createDesignPatternFromTemplate(userId,
+                                                                         requestBody,
+                                                                         requestBody.getTemplateGUID(),
+                                                                         requestBody.getReplacementProperties(),
+                                                                         requestBody.getReplacementClassifications(),
+                                                                         requestBody.getPlaceholderPropertyValues(),
+                                                                         requestBody.getParentRelationshipProperties()));
+            }
+            else
+            {
+                restExceptionHandler.handleNoRequestBody(userId, methodName, serverName);
+            }
         }
         catch (Throwable error)
         {
@@ -2093,16 +2110,23 @@ public class SolutionArchitectRESTServices extends TokenController
 
             auditLog = instanceHandler.getAuditLog(userId, serverName, methodName);
 
-            DesignPatternHandler handler = instanceHandler.getDesignPatternHandler(userId, serverName, methodName);
-
-            DesignPatternProperties properties = null;
-
-            if (requestBody.getProperties() instanceof DesignPatternProperties designPatternProperties)
+            if (requestBody != null)
             {
-                properties = designPatternProperties;
-            }
+                DesignPatternHandler handler = instanceHandler.getDesignPatternHandler(userId, serverName, methodName);
 
-            response.setFlag(handler.updateDesignPattern(userId, designPatternGUID, requestBody, properties));
+                DesignPatternProperties properties = null;
+
+                if (requestBody.getProperties() instanceof DesignPatternProperties designPatternProperties)
+                {
+                    properties = designPatternProperties;
+                }
+
+                response.setFlag(handler.updateDesignPattern(userId, designPatternGUID, requestBody, properties));
+            }
+            else
+            {
+                restExceptionHandler.handleNoRequestBody(userId, methodName, serverName);
+            }
         }
         catch (Throwable error)
         {
@@ -2149,18 +2173,29 @@ public class SolutionArchitectRESTServices extends TokenController
 
             DesignPatternHandler handler = instanceHandler.getDesignPatternHandler(userId, serverName, methodName);
 
-            NestedDesignPatternProperties properties = null;
-
-            if (requestBody.getProperties() instanceof NestedDesignPatternProperties relationshipProperties)
+            if (requestBody != null)
             {
-                properties = relationshipProperties;
-            }
+                NestedDesignPatternProperties properties = null;
 
-            handler.linkNestedDesignPatterns(userId,
-                                             parentDesignPatternGUID,
-                                             nestedDesignPatternGUID,
-                                             requestBody,
-                                             properties);
+                if (requestBody.getProperties() instanceof NestedDesignPatternProperties relationshipProperties)
+                {
+                    properties = relationshipProperties;
+                }
+
+                handler.linkNestedDesignPatterns(userId,
+                                                 parentDesignPatternGUID,
+                                                 nestedDesignPatternGUID,
+                                                 requestBody,
+                                                 properties);
+            }
+            else
+            {
+                handler.linkNestedDesignPatterns(userId,
+                                                 parentDesignPatternGUID,
+                                                 nestedDesignPatternGUID,
+                                                 null,
+                                                 null);
+            }
         }
         catch (Throwable error)
         {
@@ -2254,18 +2289,29 @@ public class SolutionArchitectRESTServices extends TokenController
 
             DesignPatternHandler handler = instanceHandler.getDesignPatternHandler(userId, serverName, methodName);
 
-            NestedDesignPatternProperties properties = null;
-
-            if (requestBody.getProperties() instanceof NestedDesignPatternProperties relationshipProperties)
+            if (requestBody != null)
             {
-                properties = relationshipProperties;
-            }
+                NestedDesignPatternProperties properties = null;
 
-            handler.linkSpecializedDesignPatterns(userId,
-                                                  generalizedDesignPatternGUID,
-                                                  specializedDesignPatternGUID,
-                                                  requestBody,
-                                                  properties);
+                if (requestBody.getProperties() instanceof NestedDesignPatternProperties relationshipProperties)
+                {
+                    properties = relationshipProperties;
+                }
+
+                handler.linkSpecializedDesignPatterns(userId,
+                                                      generalizedDesignPatternGUID,
+                                                      specializedDesignPatternGUID,
+                                                      requestBody,
+                                                      properties);
+            }
+            else
+            {
+                handler.linkSpecializedDesignPatterns(userId,
+                                                      generalizedDesignPatternGUID,
+                                                      specializedDesignPatternGUID,
+                                                      null,
+                                                      null);
+            }
         }
         catch (Throwable error)
         {
@@ -2359,18 +2405,25 @@ public class SolutionArchitectRESTServices extends TokenController
 
             DesignPatternHandler handler = instanceHandler.getDesignPatternHandler(userId, serverName, methodName);
 
-            NestedDesignPatternProperties properties = null;
-
-            if (requestBody.getProperties() instanceof NestedDesignPatternProperties relationshipProperties)
+            if (requestBody != null)
             {
-                properties = relationshipProperties;
-            }
+                NestedDesignPatternProperties properties = null;
 
-            handler.linkRelatedDesignPatterns(userId,
-                                              designPatternOneGUID,
-                                              designPatternTwoGUID,
-                                              requestBody,
-                                              properties);
+                if (requestBody.getProperties() instanceof NestedDesignPatternProperties relationshipProperties)
+                {
+                    properties = relationshipProperties;
+                }
+
+                handler.linkRelatedDesignPatterns(userId,
+                                                  designPatternOneGUID,
+                                                  designPatternTwoGUID,
+                                                  requestBody,
+                                                  properties);
+            }
+            else
+            {
+                handler.linkRelatedDesignPatterns(userId, designPatternOneGUID, designPatternTwoGUID, null, null);
+            }
         }
         catch (Throwable error)
         {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

The integration connector and governance services set the delete method to be check for lineage to prevent their components from deleting elements that are needed for lineage requests.  Unfortunately this value is passed on all delete calls and our deleteRelationship was throwing an exception.  It now handles all valid values for delete method.  It does a purge if requested and a soft-delete fore any other valid value,

## Related Issue(s)

The REST methods for Design Patterns did not handle null request bodies properly.

## Testing

Through the default configuration.

## Release Notes & Documentation

None

## Additional notes

<!-- Any Additional notes for reviewers? -->

