### PR TITLE
Correct Maven Central calls

### DIFF
--- a/.github/ISSUE_TEMPLATE/newrepo.yml
+++ b/.github/ISSUE_TEMPLATE/newrepo.yml
@@ -101,7 +101,7 @@ body:
           - Dependabot dependency updates will be set up
           - nominated owner will be responsible for managing the repo content
           - repo is public with same group/permissions as the main Egeria repo
-          - If using maven/gradle, snapshots will be published to oss.sonatype.org and releases to maven central
+          - If using maven/gradle, snapshots will be published to the Sonatype Central Portal snapshot repo and releases to maven central
           - If using containers, they will be published to quay.io & docker.io & built for arm64 + amd64 with same release versions as other artifacts
           - If using maven, versioning should follow 1.1 / 1.1-SNAPSHOT convention. For javascript etc use semver, ie 1.1.1 / 1.1.1-rc.0
           - Follows egeria branching-strategy ie branch just before release

--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -64,10 +64,9 @@ body:
         - [ ] Update release notes in [egeria-docs](https://github.com/odpi/egeria-docs/tree/main/site/docs/release-notes)
 
         Final build and publish
-        - [ ] Check if the Release pipeline release artifacts are shown in staging repo in [OSS Repository Manager](https://oss.sonatype.org/#welcome)
-        - [ ] Close staging repo & validate artifacts ok (number, structure, validations) on oss.sonatype.org 
-        - [ ] Check 'release' repo on oss.sonatype.org has artifacts
-        - [ ] Release the repo (takes time for the operation to complete and for the artifacts to be visible in maven central repository)
+        - [ ] Check the Release pipeline transferred the staging repo - the deployment should appear under [Deployments](https://central.sonatype.com/publishing/deployments) in the Central Portal
+        - [ ] Validate artifacts ok (number, structure, validations) - the deployment must reach 'VALIDATED' state
+        - [ ] Publish the deployment from the Central Portal (takes time for the operation to complete and for the artifacts to be visible in maven central repository)
         - [ ] Create final [github release](https://github.com/odpi/egeria/releases) (add link to egeria docs)
         - [ ] Update final versions of egeria-charts to release ie x.y
         - [ ] Publish that release is now shipped via slack #egeria-announce

--- a/.github/workflows/merge-v6.yml
+++ b/.github/workflows/merge-v6.yml
@@ -109,6 +109,8 @@ jobs:
           path: build/reports/jacoco/codeCoverageReport
           if-no-files-found: ignore
       # Build and publish to Maven central for main branch only - this often fails which is why it is done last
+      # main carries a -SNAPSHOT version, so build.gradle routes this to the Central Portal snapshot repo
+      # (https://central.sonatype.com/repository/maven-snapshots/) rather than the release staging area
       - name: build and publish to maven central
         if: ${{ github.ref == 'refs/heads/main'}}
         uses: gradle/gradle-build-action@v3
@@ -120,6 +122,5 @@ jobs:
           OSSRH_GPG_KEYID: ${{ secrets.OSSRH_GPG_KEYID }}
           OSSRH_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
           OSSRH_GPG_PRIVATE_KEY: ${{ secrets.OSSRH_GPG_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_mavenRepoUrl: https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/
           ORG_GRADLE_PROJECT_mavenRepoPass: ${{ secrets.OSSRH_TOKEN }}
           ORG_GRADLE_PROJECT_mavenRepoUser: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/release-v5.yml
+++ b/.github/workflows/release-v5.yml
@@ -56,7 +56,7 @@ jobs:
           OSSRH_GPG_KEYID: ${{ secrets.OSSRH_GPG_KEYID }}
           OSSRH_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
           OSSRH_GPG_PRIVATE_KEY: ${{ secrets.OSSRH_GPG_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_mavenRepoUrl: https://oss.sonatype.org/service/local/staging/deploy/maven2
+          ORG_GRADLE_PROJECT_mavenRepoUrl: https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/
           ORG_GRADLE_PROJECT_mavenRepoPass: ${{ secrets.OSSRH_TOKEN }}
           ORG_GRADLE_PROJECT_mavenRepoUser: ${{ secrets.OSSRH_USERNAME }}
       # QEMU is needed for ARM64 build for egeria-configure

--- a/.github/workflows/release-v6.yml
+++ b/.github/workflows/release-v6.yml
@@ -80,9 +80,21 @@ jobs:
           OSSRH_GPG_KEYID: ${{ secrets.OSSRH_GPG_KEYID }}
           OSSRH_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
           OSSRH_GPG_PRIVATE_KEY: ${{ secrets.OSSRH_GPG_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_mavenRepoUrl: https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/
           ORG_GRADLE_PROJECT_mavenRepoPass: ${{ secrets.OSSRH_TOKEN }}
           ORG_GRADLE_PROJECT_mavenRepoUser: ${{ secrets.OSSRH_USERNAME }}
+      # Uploading to the OSSRH staging API only leaves an open staging repository behind - it must be
+      # transferred to the Central Portal before it can be published. This request MUST come from the
+      # same IP address as the upload, so it has to stay in this job.
+      # publishing_type=user_managed means the deployment waits for a manual 'Publish' in the Portal;
+      # change to 'automatic' to release without review.
+      # Skipped for SNAPSHOT versions (eg a manual workflow_dispatch run from main) - those go
+      # straight to the snapshot repo and never create a staging repository to transfer.
+      - name: Transfer staging repository to the Central Portal
+        if: ${{ !endsWith(env.VERSION, 'SNAPSHOT') }}
+        run: |
+          curl -sS --fail-with-body -X POST \
+            -u "${{ secrets.OSSRH_USERNAME }}:${{ secrets.OSSRH_TOKEN }}" \
+            "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/org.odpi.egeria?publishing_type=user_managed"
       # Mostly for verification - not published to the release itself for now
       - name: Upload assemblies
         uses: actions/upload-artifact@v4.4.0

--- a/build.gradle
+++ b/build.gradle
@@ -205,8 +205,8 @@ subprojects {
         repositories {
             maven {
                 name = mavenRepoName
-                url = mavenRepoUrl
-                // User token (under profile) on oss.sonatype.org
+                url = version.toString().endsWith('SNAPSHOT') ? mavenSnapshotRepoUrl : mavenRepoUrl
+                // User token generated at https://central.sonatype.com/usertoken
                 credentials {
                     username = mavenRepoUser
                     password = mavenRepoPass

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,9 +32,15 @@ org.gradle.daemon.idletimeout=3600000
 # Maven publish repository name
 mavenRepoName=OSSRH
 
-# Maven publish repository url
+# Maven publish repository url for release versions
+#   Staging area on Maven Central - artifacts are transferred to the Central Portal by the release workflow
 #   it can be overridden by env variable ORG_GRADLE_PROJECT_mavenRepoUrl
 mavenRepoUrl=https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/
+
+# Maven publish repository url for SNAPSHOT versions
+#   Snapshots are not staged or validated - they go straight to the Central Portal snapshot repo
+#   it can be overridden by env variable ORG_GRADLE_PROJECT_mavenSnapshotRepoUrl
+mavenSnapshotRepoUrl=https://central.sonatype.com/repository/maven-snapshots/
 
 # Maven publish repository user
 #   it can be overridden by env variable ORG_GRADLE_PROJECT_mavenRepoUser

--- a/open-metadata-implementation/adapters/open-connectors/lovelace-insights/src/main/java/org/odpi/openmetadata/adapters/connectors/securityinsight/zoneprofile/LovelaceZoneMembershipProfilerServiceProvider.java
+++ b/open-metadata-implementation/adapters/open-connectors/lovelace-insights/src/main/java/org/odpi/openmetadata/adapters/connectors/securityinsight/zoneprofile/LovelaceZoneMembershipProfilerServiceProvider.java
@@ -5,17 +5,17 @@ package org.odpi.openmetadata.adapters.connectors.securityinsight.zoneprofile;
 
 
 import org.odpi.openmetadata.adapters.connectors.EgeriaOpenConnectorDefinition;
+import org.odpi.openmetadata.frameworks.opengovernance.GovernanceActionServiceProviderBase;
 import org.odpi.openmetadata.frameworks.opengovernance.controls.Guard;
-import org.odpi.openmetadata.frameworks.openwatchdog.WatchdogActionServiceProvider;
 
 import java.util.List;
 
 
 /**
  * LovelaceZoneMembershipProfilerServiceProvider is the OCF connector provider for the LovelaceZoneMembershipProfilerService.
- * This is a WatchDog Action Service.
+ * This is a Governance Action Service.
  */
-public class LovelaceZoneMembershipProfilerServiceProvider extends WatchdogActionServiceProvider
+public class LovelaceZoneMembershipProfilerServiceProvider extends GovernanceActionServiceProviderBase
 {
     /**
      * Constructor used to initialize the ConnectorProvider with the Java class name of the specific

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
         // releases
         mavenCentral()
         // snapshots
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
         // Once you start using pluginManagement, you should explicitly add this, unless
         // you NEVER want to use this repository
         gradlePluginPortal()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

This PR corrects the GitHub workflows to call the correct repositories for pushing to maven central.  The test is this fix

-----
# Fix provider/connector base class mismatch in LovelaceZoneMembershipProfilerService

## Description

`LovelaceZoneMembershipProfilerServiceProvider` extended `WatchdogActionServiceProvider` (OWF) while the connector class it names, `LovelaceZoneMembershipProfilerService`, extends `GeneralGovernanceActionService` (OGF). Because the provider only holds the connector class *name*, this mismatch is invisible to the compiler and only surfaces at runtime as a `ClassCastException` when an engine service casts the instantiated connector to its expected base type.

The registration metadata is consistent that this is a Governance Action Service, not a watchdog:

* `RequestTypeDefinition.BUILD_ZONE_MEMBERSHIP_PROFILE` registers the service against `GovernanceEngineDefinition.EGERIA_GOVERNANCE_ENGINE`, whose engine type is `OpenMetadataType.GOVERNANCE_ACTION_ENGINE`. (The sibling `AWARD_KARMA_POINTS` registers against `EGERIA_WATCHDOG_ENGINE` / `WATCHDOG_ACTION_ENGINE`.)
* `GovernanceServiceDefinition.BUILD_ZONE_MEMBERSHIP_PROFILE` declares `DeployedImplementationType.GOVERNANCE_ACTION_SERVICE_CONNECTOR`.
* `EgeriaOpenConnectorDefinition.ZONE_MEMBERSHIP_PROFILER_LOVELACE_SERVICE` uses the qualified name `Egeria::GovernanceService::Verification::Lovelace::ZoneMembershipProfilerService`, describes it as a Governance Action Service, and also declares `GOVERNANCE_ACTION_SERVICE_CONNECTOR`.

The behaviour of the service agrees: `start()` performs a single sweep of all governance zones, maintains the `ZoneMembershipProfile` classification on each, and then calls `recordCompletionStatus()` — a one-shot atomic action rather than a continuous listener. It is driven repeatedly as a Babbage catalog target via `LovelaceServiceDefinition.ZONE_MEMBERSHIP_PROFILE`, which is the expected pattern for a periodically re-invoked governance action.

The connector class was therefore already correct; the provider was the mismatched half. This change makes `LovelaceZoneMembershipProfilerServiceProvider` extend `GovernanceActionServiceProviderBase` instead. Both base classes share the same three-argument constructor, so this is a drop-in swap.

Notes on side effects, both benign:

* `producedGuards` was already set explicitly to the OGF `Guard.SERVICE_COMPLETED` / `Guard.SERVICE_FAILED` (not `WatchdogActionGuard`), so it is unchanged and the generated content pack output is unaffected — no archive regeneration required. `OrganizationInsightContentPack.omarchive` encodes produced guards but not the supported-request-parameter or produced-action-target specification properties that the old watchdog superclass was defaulting.
* The explicit `supportedRequestParameters = null` / `supportedActionTargetTypes = null` assignments previously served to override the watchdog defaults. They are now redundant but harmless, and they keep the constructor parallel to the sibling provider, so they have been left in place.

The class javadoc line "This is a WatchDog Action Service." was corrected to "This is a Governance Action Service." so the file is not self-contradictory. No other documentation is touched.

## Related Issue(s)

<!-- Link the issue here if one is open, e.g. Fixes #1234 -->

## Testing

* Build: `:open-metadata-implementation:adapters:open-connectors:lovelace-insights:compileJava` and `:open-metadata-resources:open-metadata-archives:core-content-pack:compileJava` both compile cleanly under JDK 17.
* Manual: server starts cleanly with no errors in the logs. The `EgeriaGovernance` engine initialises the service without logging `UNKNOWN_GOVERNANCE_ACTION_SERVICE`, which is the audit code that would fire if the provider/connector pairing were still inconsistent.

## Release Notes & Documentation

No documentation changes required. The change is internal to the connector provider and does not alter the service's qualified name, GUID, request type, produced guards, or the content pack archives. No egeria-docs update needed.

## Additional notes

For reviewers: the value of this fix is that it aligns the provider with the engine the service is actually registered in. Had the intent been the opposite — a genuine watchdog — the correct fix would instead have been to change the *service* to extend `WatchdogActionServiceConnector`, implement `processEvent()`, and move from `governanceContext` to `watchdogContext`; the registration evidence above ruled that out.

