### PR TITLE
Fix PostgresDatabaseStatsExtractor misreading negative pg_stats.n_distinct as a raw count

### DIFF
--- a/open-metadata-implementation/adapters/open-connectors/data-manager-connectors/postgres-server-connectors/build.gradle
+++ b/open-metadata-implementation/adapters/open-connectors/data-manager-connectors/postgres-server-connectors/build.gradle
@@ -31,6 +31,12 @@ dependencies {
     testImplementation 'org.testng:testng'
 }
 
+test {
+    useTestNG()
+    // This will default to standard search pattern - see https://docs.gradle.org/current/userguide/java_testing.html#sec:test_detection
+    scanForTestClasses = false
+}
+
 shadowJar {
     mainClassName = ''
     archiveClassifier = 'jar-with-dependencies'

--- a/open-metadata-implementation/adapters/open-connectors/data-manager-connectors/postgres-server-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/postgres/survey/PostgresDatabaseStatsExtractor.java
+++ b/open-metadata-implementation/adapters/open-connectors/data-manager-connectors/postgres-server-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/postgres/survey/PostgresDatabaseStatsExtractor.java
@@ -39,6 +39,31 @@ public class PostgresDatabaseStatsExtractor
 
 
     /**
+     * Convert PostgreSQL's raw pg_stats.n_distinct catalog value into an actual number-of-distinct-values
+     * estimate.  Per PostgreSQL's own documentation, a non-negative n_distinct is the estimated number of
+     * distinct values directly, but a NEGATIVE n_distinct is the negative of the ratio of distinct values
+     * to rows in the table - used for columns (such as primary keys, UUIDs and timestamps) where the number
+     * of distinct values scales with the size of the table.  Reading the raw catalog value directly as a
+     * count produces a nonsensical negative (or, once truncated to a long, zero) result for exactly these
+     * common, typically near-unique columns.
+     *
+     * @param rawDistinctStat  the raw value of pg_stats.n_distinct for the column
+     * @param tableRowCount    the table's live row-count estimate (pg_stat_user_tables.n_live_tup)
+     * @return estimated number of distinct values, never negative
+     */
+    static long calculateNumberOfDistinctValues(double rawDistinctStat,
+                                                 long   tableRowCount)
+    {
+        if (rawDistinctStat < 0)
+        {
+            return Math.round(-rawDistinctStat * tableRowCount);
+        }
+
+        return Math.round(rawDistinctStat);
+    }
+
+
+    /**
      * Retrieve statistics about each requested database.
      * This works if connected to either the postgres database or a user database.
      *
@@ -139,7 +164,7 @@ public class PostgresDatabaseStatsExtractor
                              java.sql.Connection databaseSQLConnection) throws SQLException
     {
         final String pg_tablesSQLCommand      = "select pg_stat_user_tables.relid,pg_stat_user_tables.schemaname,pg_tables.tablename, pg_tables.tableowner, pg_tables.hasindexes, pg_tables.hasrules, pg_tables.hastriggers, pg_tables.rowsecurity, pg_stat_user_tables.n_tup_ins, pg_stat_user_tables.n_tup_upd, pg_stat_user_tables.n_tup_del from pg_catalog.pg_statio_user_tables left outer join pg_catalog.pg_stat_user_tables on pg_stat_user_tables.schemaname = pg_statio_user_tables.schemaname and pg_stat_user_tables.relname = pg_statio_user_tables.relname left outer join pg_catalog.pg_tables on pg_stat_user_tables.schemaname = pg_tables.schemaname and pg_stat_user_tables.relname = pg_tables.tablename where (pg_catalog.pg_statio_user_tables.schemaname != 'pg_catalog') and (pg_catalog.pg_statio_user_tables.schemaname != 'information_schema') ;";
-        final String pg_columnStatsSQLCommand = "select pg_stats.schemaname, pg_stats.tablename, pg_statio_user_tables.relid, pg_stats.attname, pg_stats.avg_width, pg_stats.n_distinct, pg_stats.most_common_vals, pg_stats.most_common_freqs, pg_attribute.atttypid, pg_type.typname, pg_attribute.attnotnull from pg_catalog.pg_stats left outer join pg_catalog.pg_statio_user_tables on pg_stats.schemaname = pg_statio_user_tables.schemaname and pg_stats.tablename = pg_statio_user_tables.relname left outer join pg_catalog.pg_attribute on pg_statio_user_tables.relid = pg_attribute.attrelid and pg_stats.attname = pg_attribute.attname left outer join pg_type on pg_attribute.atttypid = pg_type.oid where (pg_stats.schemaname != 'pg_catalog') and (pg_stats.schemaname != 'information_schema') ;";
+        final String pg_columnStatsSQLCommand = "select pg_stats.schemaname, pg_stats.tablename, pg_statio_user_tables.relid, pg_stats.attname, pg_stats.avg_width, pg_stats.n_distinct, pg_stat_user_tables.n_live_tup, pg_stats.most_common_vals, pg_stats.most_common_freqs, pg_attribute.atttypid, pg_type.typname, pg_attribute.attnotnull from pg_catalog.pg_stats left outer join pg_catalog.pg_statio_user_tables on pg_stats.schemaname = pg_statio_user_tables.schemaname and pg_stats.tablename = pg_statio_user_tables.relname left outer join pg_catalog.pg_stat_user_tables on pg_stats.schemaname = pg_stat_user_tables.schemaname and pg_stats.tablename = pg_stat_user_tables.relname left outer join pg_catalog.pg_attribute on pg_statio_user_tables.relid = pg_attribute.attrelid and pg_stats.attname = pg_attribute.attname left outer join pg_type on pg_attribute.atttypid = pg_type.oid where (pg_stats.schemaname != 'pg_catalog') and (pg_stats.schemaname != 'information_schema') ;";
         final String pg_viewsSQLCommand       = "SELECT schemaname, viewname, viewowner, definition FROM pg_catalog.pg_views;";
         final String pg_matViewsSQLCommand    = "SELECT schemaname, matviewname, matviewowner, hasindexes, ispopulated, definition FROM pg_catalog.pg_matviews;";
 
@@ -167,7 +192,8 @@ public class PostgresDatabaseStatsExtractor
                         String  tableName              = resultSet.getString("tablename");
                         String  columnName             = resultSet.getString("attname");
                         int     averageColumnWidth     = resultSet.getInt("avg_width");
-                        long    numberOfDistinctValues = resultSet.getLong("n_distinct");
+                        long    numberOfDistinctValues = calculateNumberOfDistinctValues(resultSet.getDouble("n_distinct"),
+                                                                                          resultSet.getLong("n_live_tup"));
                         Array   mostCommonValues       = resultSet.getArray("most_common_vals");
                         Array   mostCommonFrequencies  = resultSet.getArray("most_common_freqs");
                         String  columnTypeName         = resultSet.getString("typname");

--- a/open-metadata-implementation/adapters/open-connectors/data-manager-connectors/postgres-server-connectors/src/test/java/org/odpi/openmetadata/adapters/connectors/postgres/survey/PostgresDatabaseStatsExtractorTest.java
+++ b/open-metadata-implementation/adapters/open-connectors/data-manager-connectors/postgres-server-connectors/src/test/java/org/odpi/openmetadata/adapters/connectors/postgres/survey/PostgresDatabaseStatsExtractorTest.java
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.adapters.connectors.postgres.survey;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Verify that PostgresDatabaseStatsExtractor correctly converts PostgreSQL's raw pg_stats.n_distinct
+ * catalog value into an actual number-of-distinct-values estimate, per PostgreSQL's documented semantics
+ * (see https://www.postgresql.org/docs/current/view-pg-stats.html).
+ */
+public class PostgresDatabaseStatsExtractorTest
+{
+    /**
+     * A non-negative n_distinct is already an absolute count and should pass through unchanged
+     * (allowing for rounding of the underlying real/float4 value).
+     */
+    @Test public void testNonNegativeNDistinctIsUsedDirectly()
+    {
+        assertEquals(PostgresDatabaseStatsExtractor.calculateNumberOfDistinctValues(42.0, 1_000_000L), 42L);
+        assertEquals(PostgresDatabaseStatsExtractor.calculateNumberOfDistinctValues(0.0, 1_000_000L), 0L);
+    }
+
+
+    /**
+     * A negative n_distinct is the negative of the distinct-to-row ratio, and must be scaled by the
+     * table's row count to recover an actual distinct-value estimate - not used as a count directly.
+     */
+    @Test public void testNegativeNDistinctIsScaledByRowCount()
+    {
+        // A primary-key-like column: every value distinct (ratio -1.0) in a 1,000-row table.
+        assertEquals(PostgresDatabaseStatsExtractor.calculateNumberOfDistinctValues(-1.0, 1000L), 1000L);
+
+        // A column where 25% of values are distinct (ratio -0.25) in a 2,000-row table.
+        assertEquals(PostgresDatabaseStatsExtractor.calculateNumberOfDistinctValues(-0.25, 2000L), 500L);
+    }
+
+
+    /**
+     * Before this fix, a fractional negative ratio read via ResultSet.getLong() would truncate to zero -
+     * silently hiding the fact that PostgreSQL was reporting a ratio at all. Confirm the fix does not
+     * collapse a genuinely near-unique, low-row-count column down to zero.
+     */
+    @Test public void testSmallFractionalNegativeNDistinctDoesNotTruncateToZero()
+    {
+        assertEquals(PostgresDatabaseStatsExtractor.calculateNumberOfDistinctValues(-0.95, 100L), 95L);
+    }
+
+
+    /**
+     * A table with no tracked row-count statistics yet (n_live_tup is 0, e.g. an unanalyzed or empty
+     * table) must not produce a negative distinct-value estimate.
+     */
+    @Test public void testZeroRowCountWithNegativeRatioYieldsZero()
+    {
+        assertEquals(PostgresDatabaseStatsExtractor.calculateNumberOfDistinctValues(-1.0, 0L), 0L);
+    }
+}


### PR DESCRIPTION
## Description

`PostgresDatabaseStatsExtractor.getSchemaStatistics()` reads `pg_stats.n_distinct` directly into a `long` via `ResultSet.getLong("n_distinct")` and stores it as the survey's "Number of Distinct Values" column property.

Per PostgreSQL's own documentation for the `pg_stats` catalog view (https://www.postgresql.org/docs/current/view-pg-stats.html), `n_distinct` is **not always an absolute count**:
- A non-negative value is the estimated number of distinct values, used directly.
- A **negative** value is the negative of the ratio of distinct values to rows in the table - PostgreSQL uses this for columns (such as primary keys, UUIDs, and timestamps) where the number of distinct values scales with the size of the table, since a fixed absolute estimate would go stale as the table grows.

Reading the raw catalog value directly as a count produces a nonsensical negative result in the survey property - or, once truncated by `getLong()` on a fractional negative value (e.g. `-0.95`), silently becomes `0` - for exactly these common, typically near-unique columns.

## Fix

- Added `pg_stat_user_tables.n_live_tup` (the table's own live row-count estimate) to the existing column-stats query, joined the same way `pg_stat_user_tables` is already joined elsewhere in this file for the table-level query.
- Extracted the calculation into a small, independently-testable static method, `calculateNumberOfDistinctValues(double rawDistinctStat, long tableRowCount)`, that scales the ratio by the row count when a negative `n_distinct` is reported, matching PostgreSQL's documented semantics; passes the non-negative value through unchanged otherwise.

## Testing

Added `PostgresDatabaseStatsExtractorTest` (TestNG) covering: a non-negative `n_distinct` passed through directly, a negative ratio correctly scaled by row count (including the near-unique -1.0 case), a small fractional negative ratio that would previously have truncated to zero via `getLong()`, and a zero-row-count edge case.

While verifying this, found that `postgres-server-connectors/build.gradle` was missing the `test { useTestNG() } ` block present in sibling connector modules (e.g. `jdbc-resource-connector`) - without it, `gradle test` silently finds and runs nothing for this module. Added it. Confirmed the difference directly: `gradle test` for this module found 0 tests before this change and 6 passing (the 2 pre-existing `AuditCodeTest`/`ErrorCodeTest` + 4 new) after.

Ran locally (JDK 17, Gradle):
- `compileJava` - clean
- `test` - 6/6 passing
- `checkstyleMain` / `checkstyleTest` - clean

I don't have a live PostgreSQL instance in this environment to run the full `getSchemaStatistics()` method end-to-end against a real database, so verification of the SQL query change itself is by careful review against the existing, already-working join pattern in the same file (`pg_tablesSQLCommand` already joins `pg_stat_user_tables` the same way), rather than a live run - happy to have a maintainer or CI confirm the query against a real instance.

## Additional notes

Generated with the assistance of Claude Code, reviewed and directed by me.