### PR TITLE
Fix Mendel consolidation of duplicate classifications

### DIFF
--- a/messages-and-codes/README.md
+++ b/messages-and-codes/README.md
@@ -28,7 +28,7 @@ Every Egeria message is defined once, as a constant in a *message set*.  A messa
 | Type | Message sets | Messages | Description |
 |---|---|---|---|
 | Exception messages | 66 | 614 | These messages are used to fill out the exceptions thrown by Egeria.  Each message carries an HTTP error code so that the exception can be faithfully passed across a REST API call and rebuilt by the client. |
-| Audit log messages | 104 | 913 | These messages are written to the audit log destinations configured for the OMAG Server Platform.  Each message carries a severity that describes the type of activity being reported and is used to route the message to the appropriate audit log destinations. |
+| Audit log messages | 104 | 919 | These messages are written to the audit log destinations configured for the OMAG Server Platform.  Each message carries a severity that describes the type of activity being reported and is used to route the message to the appropriate audit log destinations. |
 | Notification messages | 1 | 5 | These messages are the general purpose message sets.  They are used for message content that is neither an exception nor an audit log record - such as the notifications sent to a subscriber. |
 
 
@@ -100,7 +100,7 @@ The message sets are grouped to match the part of Egeria that defines them.
 | [Event Bus Connectors](connectors/event-bus-connectors) | 2 | 22 | These connectors send and receive events over the event bus - typically Apache Kafka. |
 | [Governance Action Connectors](connectors/governance-action-connectors) | 2 | 43 | These governance services run in an engine host to make changes to the open metadata ecosystem and the resources it describes. |
 | [File Survey Connectors](connectors/file-survey-connectors) | 1 | 5 | These survey action services analyse the content of files and folders and record what they find in a survey report. |
-| [Nanny Connectors](connectors/nanny-connectors) | 16 | 66 | The nanny connectors harvest observability data from the open metadata ecosystem into a database so that the operation of Egeria itself can be analysed. |
+| [Nanny Connectors](connectors/nanny-connectors) | 16 | 72 | The nanny connectors harvest observability data from the open metadata ecosystem into a database so that the operation of Egeria itself can be analysed. |
 | [Lovelace Insights](connectors/lovelace-insights) | 2 | 7 | These connectors analyse the harvested observability data and turn it into insight reports. |
 | [Report Generating Connectors](connectors/report-generating-connectors) | 1 | 2 | These connectors turn the contents of the open metadata ecosystem into human-readable documents. |
 | [Secrets Store Connectors](connectors/secrets-store-connectors) | 2 | 5 | These connectors supply the credentials that other connectors need when they call a third party technology. |
@@ -176,7 +176,7 @@ Every message identifier begins with a prefix that names the component that rais
 | `LISKOV-DATA-HUB-MANAGER-500-` | Exception messages | 1 | [LiskovErrorCode](connectors/nanny-connectors/LiskovErrorCode.md) |
 | `LOVELACE-INSIGHTS-` | Audit log messages | 5 | [LovelaceInsightAuditCode](connectors/lovelace-insights/LovelaceInsightAuditCode.md) |
 | `LOVELACE-INSIGHTS-500-` | Exception messages | 2 | [LovelaceInsightErrorCode](connectors/lovelace-insights/LovelaceInsightErrorCode.md) |
-| `MENDEL-DUPLICATE-MANAGER-` | Audit log messages | 10 | [MendelAuditCode](connectors/nanny-connectors/MendelAuditCode.md) |
+| `MENDEL-DUPLICATE-MANAGER-` | Audit log messages | 16 | [MendelAuditCode](connectors/nanny-connectors/MendelAuditCode.md) |
 | `MENDEL-DUPLICATE-MANAGER-500-` | Exception messages | 2 | [MendelErrorCode](connectors/nanny-connectors/MendelErrorCode.md) |
 | `METADATA-OBSERVABILITY-` | Audit log messages | 10 | [OpenMetadataObservabilityAuditCode](common-services/OpenMetadataObservabilityAuditCode.md) |
 | `MSSQL-CONNECTOR-` | Audit log messages | 6 | [MSSQLAuditCode](connectors/data-manager-connectors/MSSQLAuditCode.md) |

--- a/messages-and-codes/connectors/README.md
+++ b/messages-and-codes/connectors/README.md
@@ -18,7 +18,7 @@ Return to the [messages and codes index](../README.md).
 | [Event Bus Connectors](event-bus-connectors) | 2 | 22 | These connectors send and receive events over the event bus - typically Apache Kafka. |
 | [Governance Action Connectors](governance-action-connectors) | 2 | 43 | These governance services run in an engine host to make changes to the open metadata ecosystem and the resources it describes. |
 | [File Survey Connectors](file-survey-connectors) | 1 | 5 | These survey action services analyse the content of files and folders and record what they find in a survey report. |
-| [Nanny Connectors](nanny-connectors) | 16 | 66 | The nanny connectors harvest observability data from the open metadata ecosystem into a database so that the operation of Egeria itself can be analysed. |
+| [Nanny Connectors](nanny-connectors) | 16 | 72 | The nanny connectors harvest observability data from the open metadata ecosystem into a database so that the operation of Egeria itself can be analysed. |
 | [Lovelace Insights](lovelace-insights) | 2 | 7 | These connectors analyse the harvested observability data and turn it into insight reports. |
 | [Report Generating Connectors](report-generating-connectors) | 1 | 2 | These connectors turn the contents of the open metadata ecosystem into human-readable documents. |
 | [Secrets Store Connectors](secrets-store-connectors) | 2 | 5 | These connectors supply the credentials that other connectors need when they call a third party technology. |

--- a/messages-and-codes/connectors/nanny-connectors/MendelAuditCode.md
+++ b/messages-and-codes/connectors/nanny-connectors/MendelAuditCode.md
@@ -9,7 +9,7 @@ The MendelAuditCode is used to define the message content for the Audit Log.
 |  |  |
 |---|---|
 | **Type of message** | Audit log messages |
-| **Number of messages** | 10 |
+| **Number of messages** | 16 |
 | **Message identifiers begin** | `MENDEL-DUPLICATE-MANAGER-` |
 | **Java class** | `org.odpi.openmetadata.adapters.connectors.mendel.ffdc.MendelAuditCode` |
 | **Module** | [open-metadata-implementation/adapters/open-connectors/nanny-connectors](../../../open-metadata-implementation/adapters/open-connectors/nanny-connectors) |
@@ -28,6 +28,12 @@ The MendelAuditCode is used to define the message content for the Audit Log.
 | [MENDEL-DUPLICATE-MANAGER-0005](#mendel-duplicate-manager-0005) | INFO | The {0} integration connector has created to do {1} to request that a steward reviews the duplicate link ({2}) between elements {3} and {4} |
 | [MENDEL-DUPLICATE-MANAGER-0006](#mendel-duplicate-manager-0006) | INFO | The {0} integration connector has removed the KnownDuplicate classification from element {1} |
 | [MENDEL-DUPLICATE-MANAGER-0007](#mendel-duplicate-manager-0007) | INFO | The {0} integration connector has created consolidated element {1} from {2} duplicate {3} elements |
+| [MENDEL-DUPLICATE-MANAGER-0011](#mendel-duplicate-manager-0011) | DECISION | The {0} integration connector is discarding the value ({1}) that element {2} supplies for the {3} property, because the more recently updated element {4} in the same cluster of duplicates supplies ({5}) |
+| [MENDEL-DUPLICATE-MANAGER-0012](#mendel-duplicate-manager-0012) | DECISION | The {0} integration connector is discarding the {1} property ({2}) supplied by element {3} because it is not a property of {4}, the type of the consolidated element |
+| [MENDEL-DUPLICATE-MANAGER-0016](#mendel-duplicate-manager-0016) | DECISION | The {0} integration connector is discarding the {1} property ({2}) of the {3} classification supplied by element {4} because it is not a property of that classification |
+| [MENDEL-DUPLICATE-MANAGER-0013](#mendel-duplicate-manager-0013) | DECISION | The {0} integration connector is discarding the {1} classification ({2}) from element {3} because the more recently updated element {4} in the same cluster of duplicates carries the same classification with different properties ({5}) |
+| [MENDEL-DUPLICATE-MANAGER-0014](#mendel-duplicate-manager-0014) | DECISION | The {0} integration connector is discarding the {1} classification from element {2} because it can not be attached to {3}, the type of the consolidated element |
+| [MENDEL-DUPLICATE-MANAGER-0015](#mendel-duplicate-manager-0015) | DECISION | The {0} integration connector is not copying the {1} relationship between elements {2} and {3} onto consolidated element {4}, because the type only permits one relationship of this kind at the consolidated element's end and a more recently updated member of the cluster has supplied it |
 | [MENDEL-DUPLICATE-MANAGER-0009](#mendel-duplicate-manager-0009) | INFO | The {0} integration connector has registered a listener for open metadata events |
 | [MENDEL-DUPLICATE-MANAGER-0010](#mendel-duplicate-manager-0010) | ERROR | The {0} integration connector is unable to register a listener for open metadata events due to a {1} exception with message {2} |
 | [MENDEL-DUPLICATE-MANAGER-0008](#mendel-duplicate-manager-0008) | INFO | The {0} integration connector has stopped managing the duplicates in server {1} on platform {2} and is shutting down |
@@ -177,6 +183,132 @@ The cluster of validated duplicates has reached the size at which they are combi
 **User action**
 
 Review the consolidated element.  If it is not as expected, the survivorship rules can be adjusted by correcting the properties of the members, or the consolidation can be reversed by removing the consolidated element.
+
+
+----
+
+### MENDEL-DUPLICATE-MANAGER-0011
+
+> The {0} integration connector is discarding the value ({1}) that element {2} supplies for the {3} property, because the more recently updated element {4} in the same cluster of duplicates supplies ({5})
+
+|  |  |
+|---|---|
+| **Java constant** | `MendelAuditCode.CONFLICTING_PROPERTY` |
+| **Severity** | DECISION - A decision has been made related to the operation of the system. |
+| **Message inserts** | `{0}`, `{1}`, `{2}`, `{3}`, `{4}`, `{5}` |
+
+**System action**
+
+The consolidated element can only hold one value for a property, so it takes the value from the most recently updated member of the cluster.  The discarded value is still held by the member that supplied it, which is unchanged by the consolidation.
+
+**User action**
+
+Review the two values.  If the discarded value is the correct one, correct the member that supplied the surviving value, and delete the consolidated element so that it is rebuilt.  If the members should not have been combined at all, retire the duplicate links between them.
+
+
+----
+
+### MENDEL-DUPLICATE-MANAGER-0012
+
+> The {0} integration connector is discarding the {1} property ({2}) supplied by element {3} because it is not a property of {4}, the type of the consolidated element
+
+|  |  |
+|---|---|
+| **Java constant** | `MendelAuditCode.INCOMPATIBLE_PROPERTY` |
+| **Severity** | DECISION - A decision has been made related to the operation of the system. |
+| **Message inserts** | `{0}`, `{1}`, `{2}`, `{3}`, `{4}` |
+
+**System action**
+
+The consolidated element takes its type from the most recently updated member of the cluster.  A property that only an earlier member's type defines has nowhere to go on the consolidated element, and storing it anyway would have the repository reject the consolidation.  The property is still held by the member that supplied it, which is unchanged by the consolidation.
+
+**User action**
+
+This occurs when the members of the cluster are of different types.  Review the members: if the discarded property matters, the cluster should be consolidated into the type that defines it, which means correcting the type of the members, or the members are not duplicates of each other and their duplicate links should be retired.
+
+
+----
+
+### MENDEL-DUPLICATE-MANAGER-0016
+
+> The {0} integration connector is discarding the {1} property ({2}) of the {3} classification supplied by element {4} because it is not a property of that classification
+
+|  |  |
+|---|---|
+| **Java constant** | `MendelAuditCode.INCOMPATIBLE_CLASSIFICATION_PROPERTY` |
+| **Severity** | DECISION - A decision has been made related to the operation of the system. |
+| **Message inserts** | `{0}`, `{1}`, `{2}`, `{3}`, `{4}` |
+
+**System action**
+
+The classification is still copied to the consolidated element, but without this property.  Storing it anyway would have the repository reject the whole consolidation.  The property is still held by the member that supplied it, which is unchanged by the consolidation.
+
+**User action**
+
+A property that the classification's type does not define means the member was created against a different version of the open metadata types.  Review the member and remove or rename the property so that its classification matches the type in force.
+
+
+----
+
+### MENDEL-DUPLICATE-MANAGER-0013
+
+> The {0} integration connector is discarding the {1} classification ({2}) from element {3} because the more recently updated element {4} in the same cluster of duplicates carries the same classification with different properties ({5})
+
+|  |  |
+|---|---|
+| **Java constant** | `MendelAuditCode.CONFLICTING_CLASSIFICATION` |
+| **Severity** | DECISION - A decision has been made related to the operation of the system. |
+| **Message inserts** | `{0}`, `{1}`, `{2}`, `{3}`, `{4}`, `{5}` |
+
+**System action**
+
+Only one classification of each type can be attached to an element, so the consolidated element takes the classification from the most recently updated member of the cluster.  The discarded classification is still attached to the member that supplied it, which is unchanged by the consolidation.
+
+**User action**
+
+Review the two sets of classification properties.  If the discarded classification is the correct one, correct the member that supplied the surviving classification, and delete the consolidated element so that it is rebuilt.
+
+
+----
+
+### MENDEL-DUPLICATE-MANAGER-0014
+
+> The {0} integration connector is discarding the {1} classification from element {2} because it can not be attached to {3}, the type of the consolidated element
+
+|  |  |
+|---|---|
+| **Java constant** | `MendelAuditCode.INCOMPATIBLE_CLASSIFICATION` |
+| **Severity** | DECISION - A decision has been made related to the operation of the system. |
+| **Message inserts** | `{0}`, `{1}`, `{2}`, `{3}` |
+
+**System action**
+
+The consolidated element takes its type from the most recently updated member of the cluster, and a classification is only valid for the types that its definition names.  Attaching it anyway would have the repository reject the consolidation.  The classification is still attached to the member that supplied it, which is unchanged by the consolidation.
+
+**User action**
+
+This occurs when the members of the cluster are of different types.  Review the members: if the discarded classification matters, the cluster should be consolidated into a type that it can be attached to, which means correcting the type of the members, or the members are not duplicates of each other and their duplicate links should be retired.
+
+
+----
+
+### MENDEL-DUPLICATE-MANAGER-0015
+
+> The {0} integration connector is not copying the {1} relationship between elements {2} and {3} onto consolidated element {4}, because the type only permits one relationship of this kind at the consolidated element's end and a more recently updated member of the cluster has supplied it
+
+|  |  |
+|---|---|
+| **Java constant** | `MendelAuditCode.CONFLICTING_RELATIONSHIP` |
+| **Severity** | DECISION - A decision has been made related to the operation of the system. |
+| **Message inserts** | `{0}`, `{1}`, `{2}`, `{3}`, `{4}` |
+
+**System action**
+
+The consolidated element keeps the relationship from the most recently updated member of the cluster.  The relationship that is not copied is still in place on the member that supplied it, which is unchanged by the consolidation.
+
+**User action**
+
+Review the relationships of the members.  If the relationship that was not copied is the correct one, correct the member that supplied the surviving relationship, and delete the consolidated element so that it is rebuilt.
 
 
 ----

--- a/messages-and-codes/connectors/nanny-connectors/README.md
+++ b/messages-and-codes/connectors/nanny-connectors/README.md
@@ -6,7 +6,7 @@
 
 The nanny connectors harvest observability data from the open metadata ecosystem into a database so that the operation of Egeria itself can be analysed.
 
-This directory documents 66 messages in 16 message sets.  Return to the [messages and codes index](../../README.md).
+This directory documents 72 messages in 16 message sets.  Return to the [messages and codes index](../../README.md).
 
 
 ## Message sets
@@ -25,7 +25,7 @@ This directory documents 66 messages in 16 message sets.  Return to the [message
 | [JacquardErrorCode](JacquardErrorCode.md) | Exception messages | `JACQUARD-HARVESTER-` | 2 | <https://egeria-project.org/patterns/harvest-and-publish/overview/> |
 | [LiskovAuditCode](LiskovAuditCode.md) | Audit log messages | `LISKOV-DATA-HUB-MANAGER-` | 10 | <https://egeria-project.org/concepts/data-sharing-hub/> |
 | [LiskovErrorCode](LiskovErrorCode.md) | Exception messages | `LISKOV-DATA-HUB-MANAGER-500-` | 1 | <https://egeria-project.org/concepts/data-sharing-hub/> |
-| [MendelAuditCode](MendelAuditCode.md) | Audit log messages | `MENDEL-DUPLICATE-MANAGER-` | 10 | <https://egeria-project.org/features/duplicate-management/overview/> |
+| [MendelAuditCode](MendelAuditCode.md) | Audit log messages | `MENDEL-DUPLICATE-MANAGER-` | 16 | <https://egeria-project.org/features/duplicate-management/overview/> |
 | [MendelErrorCode](MendelErrorCode.md) | Exception messages | `MENDEL-DUPLICATE-MANAGER-500-` | 2 | <https://egeria-project.org/features/duplicate-management/overview/> |
 | [TabularDataAuditCode](TabularDataAuditCode.md) | Audit log messages | `TABULAR-METADATA-CONNECTORS-` | 1 | <https://egeria-project.org/concepts/tabular-data-set-connector/> |
 | [TabularDataErrorCode](TabularDataErrorCode.md) | Exception messages | `REFERENCE-DATA-CONNECTORS-` | 6 | <https://egeria-project.org/concepts/tabular-data-set-connector/> |

--- a/open-metadata-implementation/adapters/open-connectors/nanny-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/mendel/MendelDuplicateConsolidator.java
+++ b/open-metadata-implementation/adapters/open-connectors/nanny-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/mendel/MendelDuplicateConsolidator.java
@@ -8,11 +8,15 @@ import org.odpi.openmetadata.frameworks.integration.context.IntegrationContext;
 import org.odpi.openmetadata.frameworks.openmetadata.connectorcontext.ClassificationExplorerClient;
 import org.odpi.openmetadata.frameworks.openmetadata.connectorcontext.ConnectorContextClientBase;
 import org.odpi.openmetadata.frameworks.openmetadata.connectorcontext.OpenMetadataStore;
+import org.odpi.openmetadata.frameworks.openmetadata.properties.AttachedClassification;
+import org.odpi.openmetadata.frameworks.openmetadata.properties.OpenMetadataClassificationDef;
 import org.odpi.openmetadata.frameworks.openmetadata.properties.OpenMetadataElement;
 import org.odpi.openmetadata.frameworks.openmetadata.properties.OpenMetadataElementStub;
 import org.odpi.openmetadata.frameworks.openmetadata.properties.OpenMetadataRelationshipDef;
 import org.odpi.openmetadata.frameworks.openmetadata.properties.OpenMetadataRelationshipEndCardinality;
 import org.odpi.openmetadata.frameworks.openmetadata.properties.OpenMetadataTypeDef;
+import org.odpi.openmetadata.frameworks.openmetadata.properties.OpenMetadataTypeDefAttribute;
+import org.odpi.openmetadata.frameworks.openmetadata.properties.OpenMetadataTypeDefLink;
 import org.odpi.openmetadata.frameworks.openmetadata.properties.RelatedMetadataElement;
 import org.odpi.openmetadata.frameworks.openmetadata.properties.RelatedMetadataElementList;
 import org.odpi.openmetadata.frameworks.openmetadata.refdata.StatusIdentifier;
@@ -35,6 +39,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -45,10 +50,18 @@ import java.util.Set;
  *     version supplies is added, so nothing that a member knows about is lost.</li>
  *     <li>The qualified name is derived rather than inherited - the original with the ISO-8601 time of the
  *     merge appended - because a qualified name is unique and the members still hold theirs.</li>
+ *     <li>The classifications of all of the members are combined.  Where more than one member carries the same
+ *     classification, the one from the latest member wins.</li>
  *     <li>The relationships of all of the members are combined.  A relationship is skipped when adding it would
  *     break the cardinality rules of its type - and where two members conflict on a relationship that the type
  *     only permits one of, the one from the latest member wins.</li>
  * </ul>
+ * Wherever the survivorship rules have to choose - two members disagree on the value of a property or of a
+ * classification, or the consolidated element can only carry one of two relationships - the losing value is
+ * reported to the audit log so that a steward can see what the consolidated element left behind.  The same is
+ * done for the content that can not be carried at all: a cluster whose members are of different types can hold
+ * properties and classifications that the consolidated element's type does not allow.
+ * <br><br>
  * The consolidated element carries the ConsolidatedDuplicate classification with a status of VALIDATED, and is
  * linked to each of its members with a ConsolidatedDuplicateLink relationship.  That combination causes the
  * retrieval processing to return the consolidated element in place of the members.
@@ -67,9 +80,25 @@ public class MendelDuplicateConsolidator
                                                                           OpenMetadataType.CONSOLIDATED_DUPLICATE_LINK.typeName);
 
     /**
+     * The classifications that describe the duplicate processing itself are not copied to the consolidated element:
+     * it is the survivor of the cluster rather than another member of it.  Neither is Anchors, because the
+     * consolidated element is created as its own anchor, nor Memento, because a member being archived says nothing
+     * about the element that replaces the whole cluster.
+     */
+    private static final List<String> excludedClassificationTypes = List.of(OpenMetadataType.KNOWN_DUPLICATE_CLASSIFICATION.typeName,
+                                                                            OpenMetadataType.CONSOLIDATED_DUPLICATE_CLASSIFICATION.typeName,
+                                                                            OpenMetadataType.ANCHORS_CLASSIFICATION.typeName,
+                                                                            OpenMetadataType.MEMENTO_CLASSIFICATION.typeName);
+
+    /**
      * Cache of the relationship type definitions used to test the cardinality rules.
      */
     private final Map<String, OpenMetadataRelationshipDef> relationshipTypeDefs = new HashMap<>();
+
+    /**
+     * Cache of the classification type definitions used to test which elements a classification can be attached to.
+     */
+    private final Map<String, OpenMetadataClassificationDef> classificationTypeDefs = new HashMap<>();
 
 
     /**
@@ -188,7 +217,7 @@ public class MendelDuplicateConsolidator
 
 
     /**
-     * Create the consolidated element from the merged properties of the cluster's members.
+     * Create the consolidated element from the merged properties and classifications of the cluster's members.
      *
      * @param latestMember the most recently updated member - it supplies the type of the consolidated element
      * @param clusterMembers the members of the cluster, latest first
@@ -203,36 +232,7 @@ public class MendelDuplicateConsolidator
 
         OpenMetadataStore openMetadataStore = integrationContext.getOpenMetadataStore();
 
-        /*
-         * Start with the latest member's properties and fill in any property that only the earlier members supply.
-         */
-        ElementProperties consolidatedProperties = new ElementProperties();
-
-        /*
-         * The property names that have been taken are tracked here rather than read back from the properties
-         * being built: getPropertyValueMap() answers null while the set is empty, and returns a copy once it
-         * is not, so it can neither be tested nor added to directly.
-         */
-        Set<String> propertyNamesTaken = new HashSet<>();
-
-        for (OpenMetadataElement clusterMember : clusterMembers)
-        {
-            if (clusterMember.getElementProperties() != null)
-            {
-                Map<String, PropertyValue> memberProperties = clusterMember.getElementProperties().getPropertyValueMap();
-
-                if (memberProperties != null)
-                {
-                    for (Map.Entry<String, PropertyValue> memberProperty : memberProperties.entrySet())
-                    {
-                        if (propertyNamesTaken.add(memberProperty.getKey()))
-                        {
-                            consolidatedProperties.setProperty(memberProperty.getKey(), memberProperty.getValue());
-                        }
-                    }
-                }
-            }
-        }
+        ElementProperties consolidatedProperties = this.getConsolidatedProperties(latestMember, clusterMembers);
 
         /*
          * The qualified name is the one exception to taking the latest member's value.  A qualified name is
@@ -258,8 +258,14 @@ public class MendelDuplicateConsolidator
         }
 
         /*
+         * The consolidated element stands in for its members, so it carries their classifications too.
+         */
+        Map<String, NewElementProperties> initialClassifications = this.getConsolidatedClassifications(latestMember, clusterMembers);
+
+        /*
          * The consolidated element must carry a validated ConsolidatedDuplicate classification, otherwise the
-         * retrieval processing ignores it and continues to return the members separately.
+         * retrieval processing ignores it and continues to return the members separately.  It is added last so
+         * that it can not be displaced by anything picked up from the members.
          */
         ElementProperties classificationProperties = propertyHelper.addIntProperty(null,
                                                                                    OpenMetadataProperty.STATUS_IDENTIFIER.name,
@@ -268,8 +274,6 @@ public class MendelDuplicateConsolidator
         classificationProperties = propertyHelper.addStringProperty(classificationProperties,
                                                                     OpenMetadataProperty.SOURCE.name,
                                                                     connectorName);
-
-        Map<String, NewElementProperties> initialClassifications = new HashMap<>();
 
         initialClassifications.put(OpenMetadataType.CONSOLIDATED_DUPLICATE_CLASSIFICATION.typeName,
                                    new NewElementProperties(classificationProperties));
@@ -284,6 +288,406 @@ public class MendelDuplicateConsolidator
                                                               initialClassifications,
                                                               new NewElementProperties(consolidatedProperties),
                                                               null);
+    }
+
+
+    /**
+     * Merge the properties of the cluster's members.  The members are processed latest first, so the latest
+     * member's value of a property wins and the earlier members only fill in the properties that it does not
+     * supply.  Where an earlier member disagrees with the value that has already been taken, or supplies a
+     * property that the consolidated element's type does not define, the value that is dropped is reported to
+     * the audit log.
+     *
+     * @param latestMember the most recently updated member - it supplies the type of the consolidated element
+     * @param clusterMembers the members of the cluster, latest first
+     * @return merged properties
+     *
+     * @throws Exception the type of the consolidated element could not be retrieved - reported by the caller
+     */
+    private ElementProperties getConsolidatedProperties(OpenMetadataElement       latestMember,
+                                                        List<OpenMetadataElement> clusterMembers) throws Exception
+    {
+        final String methodName = "getConsolidatedProperties";
+
+        String consolidatedTypeName = latestMember.getType().getTypeName();
+
+        /*
+         * A null answer means that nothing is known about the type's properties, in which case everything the
+         * members supply is passed on and the repository has the final say.
+         */
+        Set<String> validPropertyNames = this.getValidPropertyNames(integrationContext.getOpenMetadataTypesClient().getTypeDefByName(true,
+                                                                                                                                     false,
+                                                                                                                                     consolidatedTypeName));
+
+        ElementProperties consolidatedProperties = new ElementProperties();
+
+        /*
+         * The property values that have been taken are tracked here rather than read back from the properties
+         * being built: getPropertyValueMap() answers null while the set is empty, and returns a copy once it
+         * is not, so it can neither be tested nor added to directly.  The member that supplied each value is
+         * kept alongside it so that a later conflict can name both sides.
+         */
+        Map<String, PropertyValue> valuesTaken    = new HashMap<>();
+        Map<String, String>        valueSuppliers = new HashMap<>();
+
+        for (OpenMetadataElement clusterMember : clusterMembers)
+        {
+            if (clusterMember.getElementProperties() != null)
+            {
+                Map<String, PropertyValue> memberProperties = clusterMember.getElementProperties().getPropertyValueMap();
+
+                if (memberProperties != null)
+                {
+                    for (Map.Entry<String, PropertyValue> memberProperty : memberProperties.entrySet())
+                    {
+                        String        propertyName  = memberProperty.getKey();
+                        PropertyValue propertyValue = memberProperty.getValue();
+
+                        if ((validPropertyNames != null) && (! validPropertyNames.contains(propertyName)))
+                        {
+                            /*
+                             * The consolidated element takes its type from the latest member, so a property that
+                             * only an earlier member's type defines has nowhere to go.  Storing it anyway would
+                             * have the repository reject the whole consolidation.
+                             */
+                            auditLog.logMessage(methodName,
+                                                MendelAuditCode.INCOMPATIBLE_PROPERTY.getMessageDefinition(connectorName,
+                                                                                                           propertyName,
+                                                                                                           this.getValueAsString(propertyValue),
+                                                                                                           clusterMember.getElementGUID(),
+                                                                                                           consolidatedTypeName));
+                        }
+                        else if (! valuesTaken.containsKey(propertyName))
+                        {
+                            valuesTaken.put(propertyName, propertyValue);
+                            valueSuppliers.put(propertyName, clusterMember.getElementGUID());
+
+                            consolidatedProperties.setProperty(propertyName, propertyValue);
+                        }
+                        else if (! Objects.equals(valuesTaken.get(propertyName), propertyValue))
+                        {
+                            /*
+                             * The qualified name is left out of this check.  The members of a cluster are
+                             * expected to disagree on it - and the consolidated element takes neither value,
+                             * since it is given a derived one - so reporting it as a conflict is just noise.
+                             */
+                            if (! OpenMetadataProperty.QUALIFIED_NAME.name.equals(propertyName))
+                            {
+                                auditLog.logMessage(methodName,
+                                                    MendelAuditCode.CONFLICTING_PROPERTY.getMessageDefinition(connectorName,
+                                                                                                              this.getValueAsString(propertyValue),
+                                                                                                              clusterMember.getElementGUID(),
+                                                                                                              propertyName,
+                                                                                                              valueSuppliers.get(propertyName),
+                                                                                                              this.getValueAsString(valuesTaken.get(propertyName))));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return consolidatedProperties;
+    }
+
+
+    /**
+     * Merge the classifications of the cluster's members.  Only one classification of each type can be attached
+     * to an element, so the members are processed latest first and the latest member's version of a
+     * classification wins.  A classification that is dropped - because a later member has already supplied one
+     * with different properties, or because it can not be attached to the consolidated element's type - is
+     * reported to the audit log.
+     *
+     * @param latestMember the most recently updated member - it supplies the type of the consolidated element
+     * @param clusterMembers the members of the cluster, latest first
+     * @return the classifications to create the consolidated element with
+     *
+     * @throws Exception a classification type could not be retrieved - reported by the caller
+     */
+    private Map<String, NewElementProperties> getConsolidatedClassifications(OpenMetadataElement       latestMember,
+                                                                             List<OpenMetadataElement> clusterMembers) throws Exception
+    {
+        final String methodName = "getConsolidatedClassifications";
+
+        Map<String, NewElementProperties> consolidatedClassifications = new HashMap<>();
+
+        /*
+         * The classifications that have been taken are tracked in their original form so that the properties of
+         * a later one can be compared with them, alongside the member that supplied each one so that a conflict
+         * can name both sides.
+         */
+        Map<String, AttachedClassification> classificationsTaken    = new HashMap<>();
+        Map<String, String>                 classificationSuppliers = new HashMap<>();
+
+        for (OpenMetadataElement clusterMember : clusterMembers)
+        {
+            if (clusterMember.getClassifications() != null)
+            {
+                for (AttachedClassification classification : clusterMember.getClassifications())
+                {
+                    if ((classification == null) || (classification.getClassificationName() == null))
+                    {
+                        continue;
+                    }
+
+                    String classificationName = classification.getClassificationName();
+
+                    if (excludedClassificationTypes.contains(classificationName))
+                    {
+                        continue;
+                    }
+
+                    AttachedClassification classificationTaken = classificationsTaken.get(classificationName);
+
+                    if (classificationTaken == null)
+                    {
+                        if (! this.isValidClassification(classificationName, latestMember))
+                        {
+                            auditLog.logMessage(methodName,
+                                                MendelAuditCode.INCOMPATIBLE_CLASSIFICATION.getMessageDefinition(connectorName,
+                                                                                                                 classificationName,
+                                                                                                                 clusterMember.getElementGUID(),
+                                                                                                                 latestMember.getType().getTypeName()));
+                            continue;
+                        }
+
+                        classificationsTaken.put(classificationName, classification);
+                        classificationSuppliers.put(classificationName, clusterMember.getElementGUID());
+
+                        consolidatedClassifications.put(classificationName,
+                                                         this.getClassificationProperties(classification, clusterMember.getElementGUID()));
+                    }
+                    else if (! this.samePropertyValues(classificationTaken.getClassificationProperties(),
+                                                        classification.getClassificationProperties()))
+                    {
+                        auditLog.logMessage(methodName,
+                                            MendelAuditCode.CONFLICTING_CLASSIFICATION.getMessageDefinition(connectorName,
+                                                                                                             classificationName,
+                                                                                                             this.getPropertiesAsString(classification.getClassificationProperties()),
+                                                                                                             clusterMember.getElementGUID(),
+                                                                                                             classificationSuppliers.get(classificationName),
+                                                                                                             this.getPropertiesAsString(classificationTaken.getClassificationProperties())));
+                    }
+                }
+            }
+        }
+
+        return consolidatedClassifications;
+    }
+
+
+    /**
+     * Return the properties to create one of the members' classifications with.  A property that the
+     * classification's type does not define - which happens when the member was created against a different
+     * version of the open metadata types - is dropped and reported, rather than being allowed to fail the
+     * whole consolidation.
+     *
+     * @param classification the member's classification
+     * @param memberGUID unique identifier of the member that supplied it - used in messages
+     * @return properties or null if the classification has none
+     *
+     * @throws Exception the classification type could not be retrieved - reported by the caller
+     */
+    private NewElementProperties getClassificationProperties(AttachedClassification classification,
+                                                             String                 memberGUID) throws Exception
+    {
+        final String methodName = "getClassificationProperties";
+
+        if (classification.getClassificationProperties() == null)
+        {
+            return null;
+        }
+
+        Map<String, PropertyValue> memberProperties = classification.getClassificationProperties().getPropertyValueMap();
+
+        if (memberProperties == null)
+        {
+            return null;
+        }
+
+        Set<String> validPropertyNames = this.getValidPropertyNames(this.getClassificationTypeDef(classification.getClassificationName()));
+
+        if (validPropertyNames == null)
+        {
+            return new NewElementProperties(classification.getClassificationProperties());
+        }
+
+        ElementProperties classificationProperties = new ElementProperties();
+
+        for (Map.Entry<String, PropertyValue> memberProperty : memberProperties.entrySet())
+        {
+            if (validPropertyNames.contains(memberProperty.getKey()))
+            {
+                classificationProperties.setProperty(memberProperty.getKey(), memberProperty.getValue());
+            }
+            else
+            {
+                auditLog.logMessage(methodName,
+                                    MendelAuditCode.INCOMPATIBLE_CLASSIFICATION_PROPERTY.getMessageDefinition(connectorName,
+                                                                                                              memberProperty.getKey(),
+                                                                                                              this.getValueAsString(memberProperty.getValue()),
+                                                                                                              classification.getClassificationName(),
+                                                                                                              memberGUID));
+            }
+        }
+
+        return new NewElementProperties(classificationProperties);
+    }
+
+
+    /**
+     * Determine whether a classification can be attached to the consolidated element.  The members of a cluster
+     * are not necessarily all of the same type - a steward can validate a duplicate link between elements of
+     * different types - so a classification that is valid for one member is not necessarily valid for the type
+     * that the consolidated element takes from the latest member.
+     *
+     * @param classificationName name of the classification
+     * @param latestMember the member that supplies the type of the consolidated element
+     * @return boolean flag - true means the classification can be attached
+     *
+     * @throws Exception the type could not be retrieved - reported by the caller
+     */
+    private boolean isValidClassification(String              classificationName,
+                                          OpenMetadataElement latestMember) throws Exception
+    {
+        OpenMetadataClassificationDef classificationDef = this.getClassificationTypeDef(classificationName);
+
+        if ((classificationDef == null) || (classificationDef.getValidEntityDefs() == null) || (classificationDef.getValidEntityDefs().isEmpty()))
+        {
+            /*
+             * Nothing is known about where this classification can be attached, so it is passed on and the
+             * repository has the final say.
+             */
+            return true;
+        }
+
+        List<String> validEntityTypeNames = new ArrayList<>();
+
+        for (OpenMetadataTypeDefLink validEntityDef : classificationDef.getValidEntityDefs())
+        {
+            if ((validEntityDef != null) && (validEntityDef.getName() != null))
+            {
+                validEntityTypeNames.add(validEntityDef.getName());
+            }
+        }
+
+        return propertyHelper.isTypeOf(latestMember, validEntityTypeNames);
+    }
+
+
+    /**
+     * Retrieve the definition of a classification type, caching it for the other members that carry it.
+     *
+     * @param classificationName name of the classification type
+     * @return type definition or null if it is not a classification type
+     *
+     * @throws Exception the type could not be retrieved - reported by the caller
+     */
+    private OpenMetadataClassificationDef getClassificationTypeDef(String classificationName) throws Exception
+    {
+        if (classificationTypeDefs.containsKey(classificationName))
+        {
+            return classificationTypeDefs.get(classificationName);
+        }
+
+        OpenMetadataTypeDef           typeDef           = integrationContext.getOpenMetadataTypesClient().getTypeDefByName(true, false, classificationName);
+        OpenMetadataClassificationDef classificationDef = null;
+
+        if (typeDef instanceof OpenMetadataClassificationDef retrievedClassificationDef)
+        {
+            classificationDef = retrievedClassificationDef;
+        }
+
+        classificationTypeDefs.put(classificationName, classificationDef);
+
+        return classificationDef;
+    }
+
+
+    /**
+     * Return the names of the properties that a type defines, including the ones it inherits from its
+     * supertypes.
+     *
+     * @param typeDef the type definition to read - it must have been retrieved with inherited attributes
+     * @return property names, or null if the type's properties are not known
+     */
+    private Set<String> getValidPropertyNames(OpenMetadataTypeDef typeDef)
+    {
+        if ((typeDef == null) || (typeDef.getAttributeDefinitions() == null) || (typeDef.getAttributeDefinitions().isEmpty()))
+        {
+            return null;
+        }
+
+        Set<String> validPropertyNames = new HashSet<>();
+
+        for (OpenMetadataTypeDefAttribute attributeDefinition : typeDef.getAttributeDefinitions())
+        {
+            if ((attributeDefinition != null) && (attributeDefinition.getAttributeName() != null))
+            {
+                validPropertyNames.add(attributeDefinition.getAttributeName());
+            }
+        }
+
+        return validPropertyNames;
+    }
+
+
+    /**
+     * Determine whether two sets of properties hold the same values.  The comparison goes through the property
+     * value maps because an empty set of properties and no properties at all mean the same thing here.
+     *
+     * @param propertiesOne first set of properties
+     * @param propertiesTwo second set of properties
+     * @return boolean flag
+     */
+    private boolean samePropertyValues(ElementProperties propertiesOne,
+                                       ElementProperties propertiesTwo)
+    {
+        Map<String, PropertyValue> valuesOne = (propertiesOne == null) ? null : propertiesOne.getPropertyValueMap();
+        Map<String, PropertyValue> valuesTwo = (propertiesTwo == null) ? null : propertiesTwo.getPropertyValueMap();
+
+        return Objects.equals(valuesOne, valuesTwo);
+    }
+
+
+    /**
+     * Return a property value in a form that can be inserted into an audit log message.
+     *
+     * @param propertyValue value to convert
+     * @return printable value
+     */
+    private String getValueAsString(PropertyValue propertyValue)
+    {
+        if (propertyValue == null)
+        {
+            return "<null>";
+        }
+
+        return propertyValue.valueAsString();
+    }
+
+
+    /**
+     * Return a set of properties in a form that can be inserted into an audit log message.
+     *
+     * @param properties properties to convert
+     * @return printable properties
+     */
+    private String getPropertiesAsString(ElementProperties properties)
+    {
+        if (properties == null)
+        {
+            return "<none>";
+        }
+
+        Map<String, String> propertiesAsStrings = properties.getPropertiesAsStrings();
+
+        if (propertiesAsStrings == null)
+        {
+            return "<none>";
+        }
+
+        return propertiesAsStrings.toString();
     }
 
 
@@ -309,15 +713,15 @@ public class MendelDuplicateConsolidator
         Set<String> attachedPairs        = new HashSet<>();
         Set<String> singletonEndsUsed    = new HashSet<>();
 
+        Set<String> memberGUIDs = new HashSet<>();
+
+        for (OpenMetadataElement member : clusterMembers)
+        {
+            memberGUIDs.add(member.getElementGUID());
+        }
+
         for (OpenMetadataElement clusterMember : clusterMembers)
         {
-            Set<String> memberGUIDs = new HashSet<>();
-
-            for (OpenMetadataElement member : clusterMembers)
-            {
-                memberGUIDs.add(member.getElementGUID());
-            }
-
             int startFrom = 0;
 
             RelatedMetadataElementList relatedElements = openMetadataStore.getRelatedMetadataElements(clusterMember.getElementGUID(),
@@ -329,7 +733,12 @@ public class MendelDuplicateConsolidator
             {
                 for (RelatedMetadataElement relatedElement : relatedElements.getElementList())
                 {
-                    this.combineRelationship(consolidatedElementGUID, relatedElement, memberGUIDs, attachedPairs, singletonEndsUsed);
+                    this.combineRelationship(consolidatedElementGUID,
+                                             clusterMember.getElementGUID(),
+                                             relatedElement,
+                                             memberGUIDs,
+                                             attachedPairs,
+                                             singletonEndsUsed);
                 }
 
                 startFrom = startFrom + integrationContext.getMaxPageSize();
@@ -347,6 +756,7 @@ public class MendelDuplicateConsolidator
      * Copy one of a member's relationships onto the consolidated element, if the cardinality rules allow it.
      *
      * @param consolidatedElementGUID unique identifier of the consolidated element
+     * @param memberGUID unique identifier of the member whose relationship this is - used in messages
      * @param relatedElement the member's relationship
      * @param memberGUIDs the members of the cluster - relationships between members are not copied
      * @param attachedPairs the pairs of elements already linked by each type of relationship
@@ -355,11 +765,14 @@ public class MendelDuplicateConsolidator
      * @throws Exception the creation failed - reported by the caller
      */
     private void combineRelationship(String                 consolidatedElementGUID,
+                                     String                 memberGUID,
                                      RelatedMetadataElement relatedElement,
                                      Set<String>            memberGUIDs,
                                      Set<String>            attachedPairs,
                                      Set<String>            singletonEndsUsed) throws Exception
     {
+        final String methodName = "combineRelationship";
+
         if ((relatedElement == null) || (relatedElement.getType() == null) || (relatedElement.getElement() == null))
         {
             return;
@@ -407,6 +820,12 @@ public class MendelDuplicateConsolidator
 
             if (! singletonEndsUsed.add(singletonKey))
             {
+                auditLog.logMessage(methodName,
+                                    MendelAuditCode.CONFLICTING_RELATIONSHIP.getMessageDefinition(connectorName,
+                                                                                                  relationshipTypeName,
+                                                                                                  memberGUID,
+                                                                                                  otherElementGUID,
+                                                                                                  consolidatedElementGUID));
                 return;
             }
         }

--- a/open-metadata-implementation/adapters/open-connectors/nanny-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/mendel/ffdc/MendelAuditCode.java
+++ b/open-metadata-implementation/adapters/open-connectors/nanny-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/mendel/ffdc/MendelAuditCode.java
@@ -113,6 +113,112 @@ public enum MendelAuditCode implements AuditLogMessageSet
                             "https://egeria-project.org/features/duplicate-management/overview/"),
 
     /**
+     * MENDEL-DUPLICATE-MANAGER-0011 - The {0} integration connector is discarding the value ({1}) that element {2} supplies for
+     * the {3} property, because the more recently updated element {4} in the same cluster of duplicates supplies ({5})
+     */
+    CONFLICTING_PROPERTY("MENDEL-DUPLICATE-MANAGER-0011",
+                         AuditLogRecordSeverityLevel.DECISION,
+                         "The {0} integration connector is discarding the value ({1}) that element {2} supplies for the {3} property, " +
+                                 "because the more recently updated element {4} in the same cluster of duplicates supplies ({5})",
+                         "The consolidated element can only hold one value for a property, so it takes the value from the most " +
+                                 "recently updated member of the cluster.  The discarded value is still held by the member that " +
+                                 "supplied it, which is unchanged by the consolidation.",
+                         "Review the two values.  If the discarded value is the correct one, correct the member that supplied the " +
+                                 "surviving value, and delete the consolidated element so that it is rebuilt.  If the members should " +
+                                 "not have been combined at all, retire the duplicate links between them.",
+                         "https://egeria-project.org/features/duplicate-management/overview/"),
+
+    /**
+     * MENDEL-DUPLICATE-MANAGER-0012 - The {0} integration connector is discarding the {1} property ({2}) supplied by element {3}
+     * because it is not a property of {4}, the type of the consolidated element
+     */
+    INCOMPATIBLE_PROPERTY("MENDEL-DUPLICATE-MANAGER-0012",
+                          AuditLogRecordSeverityLevel.DECISION,
+                          "The {0} integration connector is discarding the {1} property ({2}) supplied by element {3} because it is " +
+                                  "not a property of {4}, the type of the consolidated element",
+                          "The consolidated element takes its type from the most recently updated member of the cluster.  A property " +
+                                  "that only an earlier member's type defines has nowhere to go on the consolidated element, and " +
+                                  "storing it anyway would have the repository reject the consolidation.  The property is still held " +
+                                  "by the member that supplied it, which is unchanged by the consolidation.",
+                          "This occurs when the members of the cluster are of different types.  Review the members: if the discarded " +
+                                  "property matters, the cluster should be consolidated into the type that defines it, which means " +
+                                  "correcting the type of the members, or the members are not duplicates of each other and their " +
+                                  "duplicate links should be retired.",
+                          "https://egeria-project.org/features/duplicate-management/overview/"),
+
+    /**
+     * MENDEL-DUPLICATE-MANAGER-0016 - The {0} integration connector is discarding the {1} property ({2}) of the {3}
+     * classification supplied by element {4} because it is not a property of that classification
+     */
+    INCOMPATIBLE_CLASSIFICATION_PROPERTY("MENDEL-DUPLICATE-MANAGER-0016",
+                                         AuditLogRecordSeverityLevel.DECISION,
+                                         "The {0} integration connector is discarding the {1} property ({2}) of the {3} classification " +
+                                                 "supplied by element {4} because it is not a property of that classification",
+                                         "The classification is still copied to the consolidated element, but without this property.  " +
+                                                 "Storing it anyway would have the repository reject the whole consolidation.  The " +
+                                                 "property is still held by the member that supplied it, which is unchanged by the " +
+                                                 "consolidation.",
+                                         "A property that the classification's type does not define means the member was created " +
+                                                 "against a different version of the open metadata types.  Review the member and " +
+                                                 "remove or rename the property so that its classification matches the type in force.",
+                                         "https://egeria-project.org/features/duplicate-management/overview/"),
+
+    /**
+     * MENDEL-DUPLICATE-MANAGER-0013 - The {0} integration connector is discarding the {1} classification ({2}) from element {3}
+     * because the more recently updated element {4} in the same cluster of duplicates carries the same classification with
+     * different properties ({5})
+     */
+    CONFLICTING_CLASSIFICATION("MENDEL-DUPLICATE-MANAGER-0013",
+                               AuditLogRecordSeverityLevel.DECISION,
+                               "The {0} integration connector is discarding the {1} classification ({2}) from element {3} because the " +
+                                       "more recently updated element {4} in the same cluster of duplicates carries the same " +
+                                       "classification with different properties ({5})",
+                               "Only one classification of each type can be attached to an element, so the consolidated element takes " +
+                                       "the classification from the most recently updated member of the cluster.  The discarded " +
+                                       "classification is still attached to the member that supplied it, which is unchanged by the " +
+                                       "consolidation.",
+                               "Review the two sets of classification properties.  If the discarded classification is the correct one, " +
+                                       "correct the member that supplied the surviving classification, and delete the consolidated " +
+                                       "element so that it is rebuilt.",
+                               "https://egeria-project.org/features/duplicate-management/overview/"),
+
+    /**
+     * MENDEL-DUPLICATE-MANAGER-0014 - The {0} integration connector is discarding the {1} classification from element {2} because
+     * it can not be attached to {3}, the type of the consolidated element
+     */
+    INCOMPATIBLE_CLASSIFICATION("MENDEL-DUPLICATE-MANAGER-0014",
+                                AuditLogRecordSeverityLevel.DECISION,
+                                "The {0} integration connector is discarding the {1} classification from element {2} because it can " +
+                                        "not be attached to {3}, the type of the consolidated element",
+                                "The consolidated element takes its type from the most recently updated member of the cluster, and a " +
+                                        "classification is only valid for the types that its definition names.  Attaching it anyway " +
+                                        "would have the repository reject the consolidation.  The classification is still attached to " +
+                                        "the member that supplied it, which is unchanged by the consolidation.",
+                                "This occurs when the members of the cluster are of different types.  Review the members: if the " +
+                                        "discarded classification matters, the cluster should be consolidated into a type that it can " +
+                                        "be attached to, which means correcting the type of the members, or the members are not " +
+                                        "duplicates of each other and their duplicate links should be retired.",
+                                "https://egeria-project.org/features/duplicate-management/overview/"),
+
+    /**
+     * MENDEL-DUPLICATE-MANAGER-0015 - The {0} integration connector is not copying the {1} relationship between elements {2} and {3}
+     * onto consolidated element {4}, because the type only permits one relationship of this kind at the consolidated element's end
+     * and a more recently updated member of the cluster has supplied it
+     */
+    CONFLICTING_RELATIONSHIP("MENDEL-DUPLICATE-MANAGER-0015",
+                             AuditLogRecordSeverityLevel.DECISION,
+                             "The {0} integration connector is not copying the {1} relationship between elements {2} and {3} onto " +
+                                     "consolidated element {4}, because the type only permits one relationship of this kind at the " +
+                                     "consolidated element's end and a more recently updated member of the cluster has supplied it",
+                             "The consolidated element keeps the relationship from the most recently updated member of the cluster.  " +
+                                     "The relationship that is not copied is still in place on the member that supplied it, which is " +
+                                     "unchanged by the consolidation.",
+                             "Review the relationships of the members.  If the relationship that was not copied is the correct one, " +
+                                     "correct the member that supplied the surviving relationship, and delete the consolidated element " +
+                                     "so that it is rebuilt.",
+                             "https://egeria-project.org/features/duplicate-management/overview/"),
+
+    /**
      * MENDEL-DUPLICATE-MANAGER-0009 - The {0} integration connector has registered a listener for open metadata events
      */
     LISTENER_REGISTERED("MENDEL-DUPLICATE-MANAGER-0009",

--- a/open-metadata-test/open-metadata-fvt/duplicate-fvt/src/test/java/org/odpi/openmetadata/duplicatefvt/DuplicateArchiveWriter.java
+++ b/open-metadata-test/open-metadata-fvt/duplicate-fvt/src/test/java/org/odpi/openmetadata/duplicatefvt/DuplicateArchiveWriter.java
@@ -197,7 +197,18 @@ class DuplicateArchiveWriter extends OMRSArchiveWriter
     {
         EntityDetail elementOne   = this.addElement(DuplicateFvtTestSupport.CLUSTER_GUID_ONE, DuplicateFvtTestSupport.CLUSTER_QUALIFIED_NAME, "Cluster member 1", true);
         EntityDetail elementTwo   = this.addElement(DuplicateFvtTestSupport.CLUSTER_GUID_TWO, DuplicateFvtTestSupport.CLUSTER_QUALIFIED_NAME, "Cluster member 2", true);
-        EntityDetail elementThree = this.addElement(DuplicateFvtTestSupport.CLUSTER_GUID_THREE, DuplicateFvtTestSupport.CLUSTER_QUALIFIED_NAME, "Cluster member 3", true);
+
+        /*
+         * Only the third member is classified.  A governance classification is something a steward attached to
+         * one of the duplicates and not to the others, so it has to survive the consolidation: the consolidated
+         * element stands in for every member, and a classification that only one member carried would otherwise
+         * be lost the moment the retrieval processing stopped returning that member.
+         */
+        EntityDetail elementThree = this.addElement(DuplicateFvtTestSupport.CLUSTER_GUID_THREE,
+                                                     DuplicateFvtTestSupport.CLUSTER_QUALIFIED_NAME,
+                                                     "Cluster member 3",
+                                                     true,
+                                                     this.getConfidentialityClassification());
 
         /*
          * A chain rather than a mesh - the cluster is the set of elements reachable through the validated
@@ -248,6 +259,26 @@ class DuplicateArchiveWriter extends OMRSArchiveWriter
                                     String  displayName,
                                     boolean knownDuplicate)
     {
+        return this.addElement(guid, qualifiedName, displayName, knownDuplicate, null);
+    }
+
+
+    /**
+     * Add one element to the archive, with a classification of its own on top of the duplicate management.
+     *
+     * @param guid unique identifier to give it - fixed, so that the tests can refer to it directly
+     * @param qualifiedName qualified name - deliberately shared with another element in most of the sets
+     * @param displayName something to tell the elements apart by in a failure message
+     * @param knownDuplicate should the KnownDuplicate classification be attached?
+     * @param extraClassification a classification of the element's own, or null if it has none
+     * @return the new entity, for use as the end of a duplicate link
+     */
+    private EntityDetail addElement(String         guid,
+                                    String         qualifiedName,
+                                    String         displayName,
+                                    boolean        knownDuplicate,
+                                    Classification extraClassification)
+    {
         InstanceProperties properties = this.addStringProperty(null, OpenMetadataProperty.QUALIFIED_NAME.name, qualifiedName);
 
         properties = this.addStringProperty(properties, OpenMetadataProperty.DISPLAY_NAME.name, displayName);
@@ -263,6 +294,16 @@ class DuplicateArchiveWriter extends OMRSArchiveWriter
                                                                  InstanceStatus.ACTIVE));
         }
 
+        if (extraClassification != null)
+        {
+            if (classifications == null)
+            {
+                classifications = new ArrayList<>();
+            }
+
+            classifications.add(extraClassification);
+        }
+
         EntityDetail entity = archiveHelper.getEntityDetail(ELEMENT_TYPE_NAME,
                                                              guid,
                                                              properties,
@@ -272,6 +313,30 @@ class DuplicateArchiveWriter extends OMRSArchiveWriter
         archiveBuilder.addEntity(entity);
 
         return entity;
+    }
+
+
+    /**
+     * Build the governance classification that one of the cluster's members carries.
+     *
+     * @return classification ready to attach to an entity
+     */
+    private Classification getConfidentialityClassification()
+    {
+        InstanceProperties properties = new InstanceProperties();
+
+        PrimitivePropertyValue levelValue = new PrimitivePropertyValue();
+
+        levelValue.setPrimitiveDefCategory(PrimitiveDefCategory.OM_PRIMITIVE_TYPE_INT);
+        levelValue.setPrimitiveValue(DuplicateFvtTestSupport.CLUSTER_CONFIDENTIALITY_LEVEL);
+        levelValue.setTypeName(PrimitiveDefCategory.OM_PRIMITIVE_TYPE_INT.getName());
+        levelValue.setTypeGUID(PrimitiveDefCategory.OM_PRIMITIVE_TYPE_INT.getGUID());
+
+        properties.setProperty(OpenMetadataProperty.CONFIDENTIALITY_LEVEL.name, levelValue);
+
+        return archiveHelper.getClassification(OpenMetadataType.CONFIDENTIALITY_CLASSIFICATION.typeName,
+                                                properties,
+                                                InstanceStatus.ACTIVE);
     }
 
 

--- a/open-metadata-test/open-metadata-fvt/duplicate-fvt/src/test/java/org/odpi/openmetadata/duplicatefvt/DuplicateFvtTestSupport.java
+++ b/open-metadata-test/open-metadata-fvt/duplicate-fvt/src/test/java/org/odpi/openmetadata/duplicatefvt/DuplicateFvtTestSupport.java
@@ -92,6 +92,13 @@ final class DuplicateFvtTestSupport
     static final String CLUSTER_LINK_GUID_TWO  = "cfe198c3-34b5-40af-93be-4e66ea61ca5a";
 
     /*
+     * A governance classification carried by exactly one of the cluster's members.  The consolidated element
+     * has to end up with it: it stands in for every member, so a classification that only one member carried
+     * is lost unless the consolidation copies it over.
+     */
+    static final int    CLUSTER_CONFIDENTIALITY_LEVEL = 3;
+
+    /*
      * Set 6 - two elements sharing a qualified name, already validated and classified, but too few of them
      * to reach the consolidation cluster size.  The repository handler combines these on retrieval and
      * Mendel leaves them alone, which makes them a stable fixture for the retrieval tests.

--- a/open-metadata-test/open-metadata-fvt/duplicate-fvt/src/test/java/org/odpi/openmetadata/duplicatefvt/MendelDuplicateManagementFVT.java
+++ b/open-metadata-test/open-metadata-fvt/duplicate-fvt/src/test/java/org/odpi/openmetadata/duplicatefvt/MendelDuplicateManagementFVT.java
@@ -221,6 +221,24 @@ public class MendelDuplicateManagementFVT
                                                               OpenMetadataType.CONSOLIDATED_DUPLICATE_CLASSIFICATION.typeName),
                     "The consolidated element is missing its ConsolidatedDuplicate classification, so the retrieval processing will"
                             + " ignore it and go on returning the members separately");
+
+        /*
+         * Only one of the members carried the Confidentiality classification.  Once the cluster is consolidated
+         * that member is no longer returned, so a consolidated element without the classification means the
+         * steward's decision has been silently dropped.
+         */
+        assertTrue(DuplicateFvtTestSupport.hasClassification(consolidatedElement,
+                                                              OpenMetadataType.CONFIDENTIALITY_CLASSIFICATION.typeName),
+                    "The consolidated element did not pick up the Confidentiality classification that cluster member "
+                            + DuplicateFvtTestSupport.CLUSTER_GUID_THREE + " carries");
+
+        /*
+         * The duplicate management classifications belong to the members, not to the element that replaces
+         * them - a consolidated element that claims to be a KnownDuplicate has nothing to be a duplicate of.
+         */
+        assertFalse(DuplicateFvtTestSupport.hasClassification(consolidatedElement,
+                                                               OpenMetadataType.KNOWN_DUPLICATE_CLASSIFICATION.typeName),
+                     "The consolidated element picked up the KnownDuplicate classification from its members");
     }
 
 


### PR DESCRIPTION
# Mendel: carry the source elements' classifications onto the consolidated duplicate

## Description

When the Mendel Automated Duplicate Manager consolidates a cluster of validated duplicates, it merges the
members' properties and relationships onto the new consolidated element - but it was dropping their
**classifications** entirely, and it was resolving every survivorship conflict silently.

Both matter because the retrieval processing returns the consolidated element *in place of* its members. A
`Confidentiality` classification that a steward had attached to one member simply disappeared from view the
moment the cluster was consolidated, and there was nothing in the audit log to say so.

### Classifications are now copied

The consolidated element is created with the classifications of its members, latest member first, so where
more than one member carries the same classification the latest one wins.

Four classifications are deliberately **not** copied:

| Classification | Why not |
|---|---|
| `KnownDuplicate` | the consolidated element is the survivor of the cluster, not another member of it |
| `ConsolidatedDuplicate` | it gets its own, with a status of `VALIDATED` |
| `Anchors` | the consolidated element is created as its own anchor |
| `Memento` | one member being archived says nothing about the element that replaces the whole cluster |

### Conflicts are reported to the audit log

Six new `DECISION` severity messages (`MENDEL-DUPLICATE-MANAGER-0011` to `-0016`), so a steward can see what
the merge left behind:

| Code | Raised when |
|---|---|
| `-0011` | two members give different values for the same property |
| `-0012` | a property is not defined for the consolidated element's type |
| `-0013` | two members carry the same classification with different properties |
| `-0014` | a classification cannot be attached to the consolidated element's type |
| `-0015` | a relationship is dropped because the type permits only one at that end |
| `-0016` | a classification carries a property its own type does not define |

`qualifiedName` is deliberately left out of the conflict check: the members of a cluster are expected to
disagree on it, and the consolidated element takes neither value since it is given a derived one.

### Incompatible content no longer fails the whole consolidation

The members of a cluster need not all be of the same type - a steward can validate a duplicate link across
types - and the consolidated element takes its type from the latest member. Properties and classifications
are now checked against the type definitions before being written, so anything that does not fit is dropped
and reported (`-0012`, `-0014`, `-0016`) rather than having the repository reject the create and lose the
consolidation altogether. This last case was not hypothetical: the FVT run caught it, see Testing below.

Also hoisted the `memberGUIDs` set out of the per-member loop in `combineRelationships`, where it was being
rebuilt identically on every pass.

## Related Issue(s)

<!-- link the issue here -->

## Testing

`duplicate-fvt` was extended and run in full against a real platform (PostgreSQL repository + Kafka broker):

- The fixture now gives one of the three cluster members a `Confidentiality` classification that the other
  two do not have, so there is something that only survives if the consolidation copies it.
- `MendelDuplicateManagementFVT` asserts the consolidated element picks that classification up, and does
  *not* pick up `KnownDuplicate`.

**The first FVT run failed, and caught a real bug in this change.** Classification *attachability* was being
validated but classification *properties* were not, so a single property the type did not define failed the
entire consolidation:

```
MENDEL-DUPLICATE-MANAGER-0001 ... InvalidParameterException during consolidateValidatedClusters:
OMRS-REPOSITORY-400-028 A property called levelIdentifier has been proposed for a metadata instance
of category ClassificationDef and type Confidentiality; it is not supported for this type
```

That is what `-0016` and the classification property filtering were added for. (The fixture was wrong too -
`Confidentiality` uses `confidentialityLevel` - and is corrected here.)

After the fix, all 12 tests pass:

| Test class | Tests | Failures |
|---|---|---|
| `MendelDuplicateManagementFVT` | 5 | 0 |
| `DeduplicationRetrievalFVT` | 5 | 0 |
| `DuplicateDetectionFVT` | 2 | 0 |

with the new messages visible in the platform's audit log:

```
MENDEL-DUPLICATE-MANAGER-0007  ... has created consolidated element ac30efa6-... from 3 duplicate Collection elements
MENDEL-DUPLICATE-MANAGER-0011  ... discarding the value (Cluster member 3) that element 0df076b6-... supplies for the
                                   displayName property, because the more recently updated element 9f1ed4d8-... in the
                                   same cluster of duplicates supplies (Cluster member 2)
```

Run with:

```
./gradlew :open-metadata-test:open-metadata-fvt:duplicate-fvt:test -PrunDuplicateFvt
```

## Release Notes & Documentation

The `MendelAuditCode` message set goes from 10 to 16 messages. `messages-and-codes/` has been regenerated
with `generateMessageDocumentation`, so the checked-in message pages are up to date.

Worth a note in egeria-docs under duplicate management: the consolidated element now carries the
classifications of the elements it was built from, and the survivorship decisions it makes are auditable.

## Additional notes

`DECISION` was chosen over `INFO` because these records are exactly what the severity describes - a choice
the connector made on its own authority that a steward may want to review. It is in the default audit log
destination's supported severity list, so the messages are visible without reconfiguration.

Unrelated to this change, but noticed while running the FVT: the build emits roughly 26,000 lines of
`Unsupported class file major version 65` stack traces from JaCoCo 0.8.8 failing to instrument JDK 21
classes. It does not fail the build, but it makes the FVT output very hard to read and is worth raising
separately.