### PR TITLE
Close the paging and classification gaps, and finish files-fvt's coverage

### DIFF
--- a/open-metadata-implementation/access-services/omf-metadata-management/omf-metadata-server/src/main/java/org/odpi/openmetadata/frameworkservices/omf/server/OpenMetadataStoreRESTServices.java
+++ b/open-metadata-implementation/access-services/omf-metadata-management/omf-metadata-server/src/main/java/org/odpi/openmetadata/frameworkservices/omf/server/OpenMetadataStoreRESTServices.java
@@ -1217,7 +1217,13 @@ public class OpenMetadataStoreRESTServices
                                                                    searchOptions.getSkipSubtypes(),
                                                                    searchProperties,
                                                                    handler.getInstanceStatuses(searchOptions.getLimitResultsByStatus()),
-                                                                   addClassificationFilters(null, searchOptions),
+                                                                   /*
+                                                                    * Cast because the two addClassificationFilters()
+                                                                    * overloads differ only in a type whose simple name
+                                                                    * is the same in both packages - the unqualified
+                                                                    * name here is the repository services' one.
+                                                                    */
+                                                                   addClassificationFilters((SearchClassifications) null, searchOptions),
                                                                    searchOptions.getAsOfTime(),
                                                                    searchOptions.getSequencingProperty(),
                                                                    handler.getSequencingOrder(searchOptions.getSequencingOrder()),
@@ -1714,6 +1720,89 @@ public class OpenMetadataStoreRESTServices
 
 
     /**
+     * Add the caller's classification filters to an OMF classification search.
+     * <br><br>
+     * The same merge as the OMRS-typed method below, for the two endpoints that take their classification
+     * search in the open metadata framework's own types rather than the repository services' ones -
+     * findMetadataElements() and countMetadataElements().  Without it those two ignore
+     * includeOnlyClassifiedElements/skipClassifiedElements entirely: unlike the search-string paths, nothing
+     * downstream of them filters on those options either, so a caller that sets one gets no filtering at all
+     * rather than filtering that happens too late.
+     * <br><br>
+     * The two are kept as separate methods rather than one converting to the other, because a conversion
+     * would be more code than the merge and would have to be maintained against both type sets.
+     *
+     * @param suppliedSearchClassifications classification search the caller supplied, or null
+     * @param queryOptions options supplied by the caller
+     * @return classification search to pass on, or null if there is no classification filtering
+     */
+    private org.odpi.openmetadata.frameworks.openmetadata.search.SearchClassifications addClassificationFilters(
+            org.odpi.openmetadata.frameworks.openmetadata.search.SearchClassifications suppliedSearchClassifications,
+            QueryOptions                                                               queryOptions)
+    {
+        if (queryOptions == null)
+        {
+            return suppliedSearchClassifications;
+        }
+
+        List<String> classificationNames = queryOptions.getIncludeOnlyClassifiedElements();
+
+        org.odpi.openmetadata.frameworks.openmetadata.search.MatchCriteria matchCriteria =
+                org.odpi.openmetadata.frameworks.openmetadata.search.MatchCriteria.ALL;
+
+        if ((classificationNames == null) || (classificationNames.isEmpty()))
+        {
+            /*
+             * "Must not have" can only be pushed down when there is nothing else in the classification
+             * search, since it inverts the match criteria for the whole search.
+             */
+            if ((suppliedSearchClassifications != null) ||
+                    (queryOptions.getSkipClassifiedElements() == null) ||
+                    (queryOptions.getSkipClassifiedElements().isEmpty()))
+            {
+                return suppliedSearchClassifications;
+            }
+
+            classificationNames = queryOptions.getSkipClassifiedElements();
+            matchCriteria       = org.odpi.openmetadata.frameworks.openmetadata.search.MatchCriteria.NONE;
+        }
+
+        List<org.odpi.openmetadata.frameworks.openmetadata.search.ClassificationCondition> classificationConditions = new ArrayList<>();
+
+        if ((suppliedSearchClassifications != null) && (suppliedSearchClassifications.getConditions() != null))
+        {
+            classificationConditions.addAll(suppliedSearchClassifications.getConditions());
+        }
+
+        for (String classificationName : classificationNames)
+        {
+            if (classificationName != null)
+            {
+                org.odpi.openmetadata.frameworks.openmetadata.search.ClassificationCondition classificationCondition =
+                        new org.odpi.openmetadata.frameworks.openmetadata.search.ClassificationCondition();
+
+                classificationCondition.setName(classificationName);
+
+                classificationConditions.add(classificationCondition);
+            }
+        }
+
+        if (classificationConditions.isEmpty())
+        {
+            return suppliedSearchClassifications;
+        }
+
+        org.odpi.openmetadata.frameworks.openmetadata.search.SearchClassifications searchClassifications =
+                new org.odpi.openmetadata.frameworks.openmetadata.search.SearchClassifications();
+
+        searchClassifications.setConditions(classificationConditions);
+        searchClassifications.setMatchCriteria(matchCriteria);
+
+        return searchClassifications;
+    }
+
+
+    /**
      * Add the caller's classification filters to the classification search that will be passed to the
      * repository, so that a page of results is a page of answers.
      * <br><br>
@@ -2097,7 +2186,7 @@ public class OpenMetadataStoreRESTServices
                                                                   requestBody.getSkipSubtypes(),
                                                                   requestBody.getSearchProperties(),
                                                                   requestBody.getLimitResultsByStatus(),
-                                                                  requestBody.getMatchClassifications(),
+                                                                  addClassificationFilters(requestBody.getMatchClassifications(), requestBody),
                                                                   requestBody.getAsOfTime(),
                                                                   requestBody.getSequencingProperty(),
                                                                   requestBody.getSequencingOrder(),
@@ -2168,7 +2257,7 @@ public class OpenMetadataStoreRESTServices
                                                                 requestBody.getSkipSubtypes(),
                                                                 requestBody.getSearchProperties(),
                                                                 requestBody.getLimitResultsByStatus(),
-                                                                requestBody.getMatchClassifications(),
+                                                                addClassificationFilters(requestBody.getMatchClassifications(), requestBody),
                                                                 requestBody.getAsOfTime(),
                                                                 requestBody.getForLineage(),
                                                                 requestBody.getForDuplicateProcessing(),

--- a/open-metadata-implementation/adapters/open-connectors/repository-services-connectors/open-metadata-collection-store-connectors/postgres-repository-connector/src/main/java/org/odpi/openmetadata/adapters/repositoryservices/postgres/repositoryconnector/database/QueryBuilder.java
+++ b/open-metadata-implementation/adapters/open-connectors/repository-services-connectors/open-metadata-collection-store-connectors/postgres-repository-connector/src/main/java/org/odpi/openmetadata/adapters/repositoryservices/postgres/repositoryconnector/database/QueryBuilder.java
@@ -2205,55 +2205,6 @@ public class QueryBuilder
     }
 
 
-    /**
-     * Join the principle table with its associated attributes table.
-     *
-     * @param principleTable main table
-     * @param propertiesTableName name of attributes table
-     * @return the join part of the SQL query
-     */
-    public String getDistinctPropertyJoinQuery(RepositoryTable principleTable,
-                                               String          propertiesTableName)
-    {
-        StringBuilder clause = new StringBuilder("select distinct ");
-
-        boolean firstColumn = true;
-
-        for (String columnName : principleTable.getQualifiedColumnNames())
-        {
-            if (firstColumn)
-            {
-                firstColumn = false;
-            }
-            else
-            {
-                clause.append(", ");
-            }
-
-            clause.append(columnName);
-        }
-
-        clause.append(" from ");
-        clause.append(principleTable.getTableName());
-        clause.append(" left outer join ");
-        clause.append(propertiesTableName);
-        clause.append(" on ");
-        clause.append(RepositoryColumn.INSTANCE_GUID.getColumnName(principleTable.getTableName()));
-        clause.append(" = ");
-        clause.append(RepositoryColumn.INSTANCE_GUID.getColumnName(propertiesTableName));
-        clause.append(" and ");
-        clause.append(RepositoryColumn.VERSION.getColumnName(principleTable.getTableName()));
-        clause.append(" = ");
-        clause.append(RepositoryColumn.VERSION.getColumnName(propertiesTableName));
-
-        if (log.isDebugEnabled())
-        {
-            log.debug(this.toString());
-            log.debug(clause.toString());
-        }
-
-        return clause.toString();
-    }
 
 
     /**

--- a/open-metadata-implementation/repository-services/repository-services-implementation/src/main/java/org/odpi/openmetadata/repositoryservices/localrepository/repositorycontentmanager/OMRSRepositoryContentHelper.java
+++ b/open-metadata-implementation/repository-services/repository-services-implementation/src/main/java/org/odpi/openmetadata/repositoryservices/localrepository/repositorycontentmanager/OMRSRepositoryContentHelper.java
@@ -2281,22 +2281,43 @@ public class OMRSRepositoryContentHelper extends OMRSRepositoryPropertiesUtiliti
             return null;
         }
 
-        // If there is no sequencing order, or it is defined as 'ANY', there is no sorting to do
-        if (sequencingOrder != null && !sequencingOrder.equals(SequencingOrder.ANY))
+        /*
+         * Every ordering ends with the instance's GUID, so that the result is a deterministic total order.
+         * The columns a caller can sequence on - creation time, update time, a property value - are none of
+         * them unique, and the results are paged: a page is a subList of this list, and the caller asks for
+         * the next one in a separate call that sorts the set again.  Rows that tie would otherwise be free
+         * to come back in a different order each time, and an instance could move between pages and be
+         * returned twice, or skipped, while the traversal terminated normally.
+         *
+         * That includes the case where nothing was asked for, or ANY was: the caller not caring which order
+         * they are given still needs each page to agree with the last.
+         */
+        if ((sequencingOrder == null) || sequencingOrder.equals(SequencingOrder.ANY))
         {
-            if (sequencingOrder.equals(SequencingOrder.PROPERTY_ASCENDING) || sequencingOrder.equals(SequencingOrder.PROPERTY_DESCENDING))
-            {
-                // If the sequencing is property-based, handover to the property comparator
-                fullResults.sort((one, two) -> this.compareProperties(one.getProperties(),
-                                                                      two.getProperties(),
-                                                                      sequencingProperty,
-                                                                      sequencingOrder));
-            }
-            else
-            {
-                // Otherwise, handover to the instance comparator
-                fullResults.sort((one, two) -> OMRSRepositoryContentHelper.compareInstances(one, two, sequencingOrder));
-            }
+            fullResults.sort(OMRSRepositoryContentHelper::compareGUIDs);
+        }
+        else if (sequencingOrder.equals(SequencingOrder.PROPERTY_ASCENDING) || sequencingOrder.equals(SequencingOrder.PROPERTY_DESCENDING))
+        {
+            // If the sequencing is property-based, handover to the property comparator
+            fullResults.sort((one, two) ->
+                             {
+                                 int sortResult = this.compareProperties(one.getProperties(),
+                                                                          two.getProperties(),
+                                                                          sequencingProperty,
+                                                                          sequencingOrder);
+
+                                 return (sortResult != 0) ? sortResult : compareGUIDs(one, two);
+                             });
+        }
+        else
+        {
+            // Otherwise, handover to the instance comparator
+            fullResults.sort((one, two) ->
+                             {
+                                 int sortResult = OMRSRepositoryContentHelper.compareInstances(one, two, sequencingOrder);
+
+                                 return (sortResult != 0) ? sortResult : compareGUIDs(one, two);
+                             });
         }
 
         if ((fromElement == 0) && (pageSize > fullResultsSize))
@@ -2351,22 +2372,43 @@ public class OMRSRepositoryContentHelper extends OMRSRepositoryPropertiesUtiliti
             return null;
         }
 
-        // If there is no sequencing order, or it is defined as 'ANY', there is no sorting to do
-        if (sequencingOrder != null && !sequencingOrder.equals(SequencingOrder.ANY))
+        /*
+         * Every ordering ends with the instance's GUID, so that the result is a deterministic total order.
+         * The columns a caller can sequence on - creation time, update time, a property value - are none of
+         * them unique, and the results are paged: a page is a subList of this list, and the caller asks for
+         * the next one in a separate call that sorts the set again.  Rows that tie would otherwise be free
+         * to come back in a different order each time, and an instance could move between pages and be
+         * returned twice, or skipped, while the traversal terminated normally.
+         *
+         * That includes the case where nothing was asked for, or ANY was: the caller not caring which order
+         * they are given still needs each page to agree with the last.
+         */
+        if ((sequencingOrder == null) || sequencingOrder.equals(SequencingOrder.ANY))
         {
-            if (sequencingOrder.equals(SequencingOrder.PROPERTY_ASCENDING) || sequencingOrder.equals(SequencingOrder.PROPERTY_DESCENDING))
-            {
-                // If the sequencing is property-based, handover to the property comparator
-                fullResults.sort((one, two) -> this.compareProperties(one.getProperties(),
-                                                                      two.getProperties(),
-                                                                      sequencingProperty,
-                                                                      sequencingOrder));
-            }
-            else
-            {
-                // Otherwise, handover to the instance comparator
-                fullResults.sort((one, two) -> OMRSRepositoryContentHelper.compareInstances(one, two, sequencingOrder));
-            }
+            fullResults.sort(OMRSRepositoryContentHelper::compareGUIDs);
+        }
+        else if (sequencingOrder.equals(SequencingOrder.PROPERTY_ASCENDING) || sequencingOrder.equals(SequencingOrder.PROPERTY_DESCENDING))
+        {
+            // If the sequencing is property-based, handover to the property comparator
+            fullResults.sort((one, two) ->
+                             {
+                                 int sortResult = this.compareProperties(one.getProperties(),
+                                                                          two.getProperties(),
+                                                                          sequencingProperty,
+                                                                          sequencingOrder);
+
+                                 return (sortResult != 0) ? sortResult : compareGUIDs(one, two);
+                             });
+        }
+        else
+        {
+            // Otherwise, handover to the instance comparator
+            fullResults.sort((one, two) ->
+                             {
+                                 int sortResult = OMRSRepositoryContentHelper.compareInstances(one, two, sequencingOrder);
+
+                                 return (sortResult != 0) ? sortResult : compareGUIDs(one, two);
+                             });
         }
 
         if ((fromElement == 0) && (pageSize == 0 || pageSize > fullResultsSize))
@@ -2380,6 +2422,34 @@ public class OMRSRepositoryContentHelper extends OMRSRepositoryPropertiesUtiliti
           toIndex = getToIndex(fromElement, pageSize, fullResultsSize);
         }
         return new ArrayList<>(fullResults.subList(fromElement, toIndex));
+    }
+
+
+    /**
+     * Compare two instances by their GUID.  This is the tie-break that makes an ordering a total order: a
+     * GUID is present and unique on every instance, whatever its type and whatever it is being sorted by.
+     *
+     * @param one the first instance
+     * @param two the second instance
+     * @return sort result
+     */
+    private static int compareGUIDs(InstanceHeader one,
+                                    InstanceHeader two)
+    {
+        String guidOne = (one == null) ? null : one.getGUID();
+        String guidTwo = (two == null) ? null : two.getGUID();
+
+        if (guidOne == null)
+        {
+            return (guidTwo == null) ? 0 : -1;
+        }
+
+        if (guidTwo == null)
+        {
+            return 1;
+        }
+
+        return guidOne.compareTo(guidTwo);
     }
 
 

--- a/open-metadata-test/open-metadata-fvt/README.md
+++ b/open-metadata-test/open-metadata-fvt/README.md
@@ -74,11 +74,12 @@ property on the command line, shown against each suite below.
   ```
 
 * **[files-fvt](files-fvt)** - tests the **file connectors** and the **Files content pack** that drives them:
-  the folder and file survey services, the folder cataloguers, and the file provisioning actions. Built the
-  same way as postgres-fvt - it stands up a metadata access store, an integration daemon, an engine host and a
-  view server, and drives them through the **Automated Curation API** rather than calling any connector
-  directly. It brings its own directory tree, so a survey of three files and a nested folder can be asserted
-  against exactly.
+  the folder and file survey services, the folder cataloguers, the file and folder governance actions, and the
+  catalog templates the cataloguer chooses between. Built the same way as postgres-fvt - it stands up a
+  metadata access store, an integration daemon, an engine host and a view server, and drives them through the
+  **Automated Curation API** rather than calling any connector directly. It brings its own directory tree, so
+  a survey of three files and a nested folder can be asserted against exactly, and a file catalogued as the
+  wrong type is a failure rather than a detail nobody looked at.
 
   ```
   ./gradlew :open-metadata-test:open-metadata-fvt:files-fvt:test -PrunFilesFvt

--- a/open-metadata-test/open-metadata-fvt/files-fvt/README.md
+++ b/open-metadata-test/open-metadata-fvt/files-fvt/README.md
@@ -107,18 +107,50 @@ type would not exercise that choice at all.
   file, or wrote the file without cataloguing it, would pass a test that looked in one place only. The three
   run in order and share a destination folder, because they are three stages of one story.
 
+* **[DataFolderActionsFVT](src/test/java/org/odpi/openmetadata/filesfvt/DataFolderActionsFVT.java)** — a data
+  folder through all three of its actions: `create-data-folder`, `catalog-data-folder`, `delete-data-folder`.
+  A `DataFolder` is not a `FileFolder` under another name — the directory *is* the data set, and the files
+  inside it are not catalogued separately — so the pack ships a separate template and separate actions, and
+  this says the second set works rather than assuming it does because the first does. The delete case is the
+  one that earns its place: `delete-data-folder` is given the template and the same placeholder values the
+  create used and derives the qualified name from them, so it is the only action here that has to work out
+  what it operates on. The test also checks the directory is **still on disk** afterwards — it removes the
+  catalogue entry, not the data, and a test that only checked the asset had gone would pass on a service that
+  deleted the user's files.
+
+* **[FileTypeCataloguingFVT](src/test/java/org/odpi/openmetadata/filesfvt/FileTypeCataloguingFVT.java)** — the
+  cataloguer picks a catalog template by the kind of file it found: a `.csv` arrives as a `CSVFile` and a
+  `.json` as a `JSONFile`, not as plain `DataFile`s. [templates-fvt](../templates-fvt) already creates an
+  element from every one of the pack's file templates directly; what is untested there, and tested here, is
+  the step before that — something has to *choose* the template. A file catalogued as the wrong type is not
+  wrong the way a missing asset is wrong; it is worse, because everything downstream that keys off the type
+  quietly stops applying. The expected types come from `DeployedImplementationType` rather than string
+  literals, so a rename in the model is a compile failure here.
+
+* **[NewFileWatchdogFVT](src/test/java/org/odpi/openmetadata/filesfvt/NewFileWatchdogFVT.java)** — starts
+  `watch-for-new-files-in-folder` on a folder and checks it is running. **This is a narrower claim than the
+  other tests make.** A watchdog does not complete: it starts, registers its interest, and stays running, so
+  waiting for a terminal status would time out on one that is working perfectly. What is asserted is that it
+  started and stayed started — which catches the failure this connector family has shown repeatedly, a
+  service that throws on start-up and so never watches anything. It does *not* show that the watchdog reacts
+  to a new file; see below.
+
 ## Still to add
 
-The four cataloguers other than the General Folder Cataloguer are checked as far as this suite honestly can -
-see `CataloguersFVT` for why cataloguing cannot be driven for them here. What is still uncovered:
+* **The watchdog's reaction.** `NewFileWatchdogFVT` shows the watchdog runs, not that it acts. Showing that
+  means cataloguing a new file inside the watched folder and waiting for the action the watchdog initiates in
+  response — a second engine action the test never requested and cannot name in advance. Worth having, and a
+  larger test than the one that is here.
 
-* the **CSV and data folder** actions - `create-data-folder`, `catalog-data-folder`, `delete-data-folder` -
-  which mirror the file folder ones already covered;
-* `watch-for-new-files-in-folder`, which is a watchdog rather than a one-shot action and needs a different
-  shape of test;
-* the twenty-odd **catalog templates** for individual file types, which
-  [templates-fvt](../templates-fvt) already creates elements from, but not through the governance actions
-  that choose between them.
+* **The file templates no governance action reaches.** `FileTypeCataloguingFVT` covers the types the folder
+  cataloguer chooses between for the files this suite writes. The pack ships around twenty templates in all —
+  Avro, Parquet, spreadsheets, source code, keystores and the rest — and the ones no action in this suite
+  drives are created directly by [templates-fvt](../templates-fvt) instead. Widening the tree to one file per
+  template would extend this suite's coverage to the choice as well as the creation.
+
+* **The other four cataloguers, driven through cataloguing.** `CataloguersFVT` checks all five are running,
+  and `FolderCatalogFVT` takes one of them all the way. The other four cannot be driven here without
+  inventing a configuration — see `CataloguersFVT` for why.
 
 ## Clean-up
 

--- a/open-metadata-test/open-metadata-fvt/files-fvt/src/test/java/org/odpi/openmetadata/filesfvt/DataFolderActionsFVT.java
+++ b/open-metadata-test/open-metadata-fvt/files-fvt/src/test/java/org/odpi/openmetadata/filesfvt/DataFolderActionsFVT.java
@@ -1,0 +1,191 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.filesfvt;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.odpi.openmetadata.contentpacks.core.RequestTypeDefinition;
+import org.odpi.openmetadata.frameworks.opengovernance.controls.ActionTarget;
+import org.odpi.openmetadata.frameworks.openmetadata.connectorcontext.OpenMetadataStore;
+import org.odpi.openmetadata.frameworks.openmetadata.enums.DeleteMethod;
+import org.odpi.openmetadata.frameworks.openmetadata.properties.OpenMetadataElement;
+import org.odpi.openmetadata.frameworks.openmetadata.properties.RelatedMetadataElementList;
+import org.odpi.openmetadata.frameworks.openmetadata.types.OpenMetadataType;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * DataFolderActionsFVT takes a data folder through the three governance actions the Files content pack ships
+ * for one: create it, hand it to a cataloguer, and delete it again.
+ * <br>
+ * A {@code DataFolder} is not a {@code FileFolder} with a different name.  A file folder is a directory whose
+ * files are catalogued individually; a data folder is a directory that <em>is</em> the data - the files inside
+ * it are how one data set happens to be stored, and are not catalogued separately.  The content pack ships a
+ * separate template and a separate set of actions for that reason, and this test is what says the second set
+ * works, rather than assuming it does because the file folder set does.
+ * <br>
+ * The delete case is the only place in this suite where an asset is removed by the content pack's own action
+ * rather than by the suite's clean-up.  That is worth having: {@code delete-data-folder} finds the asset from
+ * the template and the same placeholder values it was created with, not from a GUID handed to it, so it is
+ * the one action here that has to derive what it operates on.
+ */
+@ExtendWith(OMAGPlatformExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class DataFolderActionsFVT
+{
+    private static final RequestTypeDefinition CREATE_DATA_FOLDER  = RequestTypeDefinition.CREATE_DATA_FOLDER;
+    private static final RequestTypeDefinition CATALOG_DATA_FOLDER = RequestTypeDefinition.CATALOG_DATA_FOLDER;
+    private static final RequestTypeDefinition DELETE_DATA_FOLDER  = RequestTypeDefinition.DELETE_DATA_FOLDER;
+
+
+    @Test
+    @Order(1)
+    @DisplayName("create-data-folder catalogues the directory as a DataFolder")
+    void testCreateDataFolder() throws Exception
+    {
+        OpenMetadataStore openMetadataStore = ConnectorContextFactory.newContext(DeleteMethod.PURGE).getOpenMetadataStore();
+
+        File   folder        = FilesFvtTestSupport.folderUnderTest("datafolder");
+        String qualifiedName = FilesFvtTestSupport.dataFolderAssetQualifiedName(folder);
+
+        assertTrue(folder.isDirectory(), "The folder under test was not built: " + folder.getAbsolutePath());
+
+        runFolderAction(CREATE_DATA_FOLDER, folder);
+
+        OpenMetadataElement folderAsset = FilesFvtTestSupport.waitForElement(openMetadataStore,
+                                                                             qualifiedName,
+                                                                             "the data folder asset");
+
+        assertNotNull(folderAsset,
+                      FilesFvtTestSupport.governanceActionTypeQualifiedName(CREATE_DATA_FOLDER)
+                              + " completed but no asset called " + qualifiedName + " arrived in the repository.");
+
+        assertTrue(folderAsset.getType().getTypeName().contains(OpenMetadataType.DATA_FOLDER.typeName),
+                   "The asset was catalogued as a " + folderAsset.getType().getTypeName() + " rather than a "
+                           + OpenMetadataType.DATA_FOLDER.typeName + " - create-data-folder used the wrong template.");
+
+        List<String> survivingPlaceholders = FilesFvtTestSupport.findPlaceholders("the catalogued data folder",
+                                                                                   folderAsset.getElementProperties());
+
+        assertTrue(survivingPlaceholders.isEmpty(),
+                   "The data folder asset still carries unsubstituted placeholders: " + survivingPlaceholders);
+    }
+
+
+    @Test
+    @Order(2)
+    @DisplayName("catalog-data-folder attaches the folder to its cataloguer")
+    void testCatalogDataFolder() throws Exception
+    {
+        OpenMetadataStore openMetadataStore = ConnectorContextFactory.newContext(DeleteMethod.PURGE).getOpenMetadataStore();
+
+        File   folder        = FilesFvtTestSupport.folderUnderTest("datafolder");
+        String qualifiedName = FilesFvtTestSupport.dataFolderAssetQualifiedName(folder);
+
+        OpenMetadataElement folderAsset = openMetadataStore.getMetadataElementByUniqueName(qualifiedName,
+                                                                                           "qualifiedName");
+
+        assertNotNull(folderAsset,
+                      "The data folder asset is not there - testCreateDataFolder should have created it.");
+
+        String actionName = FilesFvtTestSupport.governanceActionTypeQualifiedName(CATALOG_DATA_FOLDER);
+
+        String engineActionGUID = new AutomatedCurationClient().initiateGovernanceActionType(
+                actionName,
+                new HashMap<>(),
+                List.of(FilesFvtTestSupport.newActionTarget(ActionTarget.NEW_ASSET.getName(),
+                                                             folderAsset.getElementGUID())));
+
+        assertNotNull(engineActionGUID,
+                      "The Automated Curation service accepted the request to run " + actionName
+                              + " but returned no engine action to follow.");
+
+        new EngineActionWaiter().waitForCompletion(engineActionGUID, actionName);
+
+        RelatedMetadataElementList targets =
+                openMetadataStore.getRelatedMetadataElements(folderAsset.getElementGUID(),
+                                                              0,
+                                                              OpenMetadataType.CATALOG_TARGET_RELATIONSHIP.typeName,
+                                                              0,
+                                                              FilesFvtTestSupport.MAX_PAGE_SIZE);
+
+        assertTrue((targets != null) && (targets.getElementList() != null) && (! targets.getElementList().isEmpty()),
+                   actionName + " completed but the data folder was not attached to a cataloguer as a catalog target,"
+                           + " so nothing will ever look inside it.");
+    }
+
+
+    @Test
+    @Order(3)
+    @DisplayName("delete-data-folder removes the asset it created")
+    void testDeleteDataFolder() throws Exception
+    {
+        OpenMetadataStore openMetadataStore = ConnectorContextFactory.newContext(DeleteMethod.PURGE).getOpenMetadataStore();
+
+        File   folder        = FilesFvtTestSupport.folderUnderTest("datafolder");
+        String qualifiedName = FilesFvtTestSupport.dataFolderAssetQualifiedName(folder);
+
+        assertNotNull(openMetadataStore.getMetadataElementByUniqueName(qualifiedName, "qualifiedName"),
+                      "The data folder asset is not there before the delete - the earlier cases should have left it.");
+
+        runFolderAction(DELETE_DATA_FOLDER, folder);
+
+        /*
+         * The asset should be gone.  Asked for by name rather than by GUID because that is how the delete
+         * service found it too: it is given the template and the placeholder values, and derives the
+         * qualified name from them.
+         */
+        FilesFvtTestSupport.waitFor("the data folder asset to be removed by "
+                                            + FilesFvtTestSupport.governanceActionTypeQualifiedName(DELETE_DATA_FOLDER),
+                                     "files.fvt.refresh.timeout.seconds",
+                                     180,
+                                     () -> openMetadataStore.getMetadataElementByUniqueName(qualifiedName, "qualifiedName") == null);
+
+        assertNull(openMetadataStore.getMetadataElementByUniqueName(qualifiedName, "qualifiedName"),
+                   FilesFvtTestSupport.governanceActionTypeQualifiedName(DELETE_DATA_FOLDER)
+                           + " completed but the asset " + qualifiedName + " is still in the repository.");
+
+        assertTrue(folder.isDirectory(),
+                   "delete-data-folder removed the directory " + folder.getAbsolutePath() + " from disk.  It removes"
+                           + " the catalogue entry, not the data.");
+    }
+
+
+    /**
+     * Run one of the folder actions, which take their subject as placeholder values rather than as an action
+     * target - the same values for create and for delete, because the delete service derives the qualified
+     * name of what it is removing from them.
+     *
+     * @param requestType action to run
+     * @param folder folder it should act on
+     * @throws Exception any failure - which is the finding
+     */
+    private void runFolderAction(RequestTypeDefinition requestType,
+                                 File                  folder) throws Exception
+    {
+        String actionName = FilesFvtTestSupport.governanceActionTypeQualifiedName(requestType);
+
+        Map<String, String> requestParameters = new HashMap<>(FilesFvtTestSupport.folderTemplatePlaceholders(folder));
+
+        String engineActionGUID = new AutomatedCurationClient().initiateGovernanceActionType(actionName,
+                                                                                              requestParameters,
+                                                                                              null);
+
+        assertNotNull(engineActionGUID,
+                      "The Automated Curation service accepted the request to run " + actionName
+                              + " but returned no engine action to follow.");
+
+        new EngineActionWaiter().waitForCompletion(engineActionGUID, actionName);
+    }
+}

--- a/open-metadata-test/open-metadata-fvt/files-fvt/src/test/java/org/odpi/openmetadata/filesfvt/FileTypeCataloguingFVT.java
+++ b/open-metadata-test/open-metadata-fvt/files-fvt/src/test/java/org/odpi/openmetadata/filesfvt/FileTypeCataloguingFVT.java
@@ -1,0 +1,193 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.filesfvt;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.odpi.openmetadata.contentpacks.core.RequestTypeDefinition;
+import org.odpi.openmetadata.frameworks.opengovernance.controls.ActionTarget;
+import org.odpi.openmetadata.frameworks.openmetadata.connectorcontext.OpenMetadataStore;
+import org.odpi.openmetadata.frameworks.openmetadata.enums.DeleteMethod;
+import org.odpi.openmetadata.frameworks.openmetadata.properties.OpenMetadataElement;
+import org.odpi.openmetadata.frameworks.openmetadata.search.PropertyComparisonOperator;
+import org.odpi.openmetadata.frameworks.openmetadata.search.PropertyHelper;
+import org.odpi.openmetadata.frameworks.openmetadata.search.QueryOptions;
+import org.odpi.openmetadata.frameworks.openmetadata.search.SearchProperties;
+import org.odpi.openmetadata.frameworks.openmetadata.types.OpenMetadataProperty;
+import org.odpi.openmetadata.frameworks.openmetadata.types.OpenMetadataType;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * FileTypeCataloguingFVT checks that the folder cataloguer picks a catalog template by the kind of file it
+ * has found, rather than cataloguing everything the same way.
+ * <br>
+ * The Files content pack ships around twenty templates for individual file types - CSV, JSON, Avro, Parquet,
+ * spreadsheets, source code, keystores - and the point of having them is that a catalogued file arrives as
+ * the type it actually is.  A CSV file catalogued as a plain {@code DataFile} is not wrong in the way a
+ * missing asset is wrong; it is worse than that, because everything downstream that keys off the type - which
+ * survey to run, which connector opens it, which governance rules apply - quietly stops applying.
+ * <br>
+ * {@link org.odpi.openmetadata.templatesfvt.ContentPackTemplateFVT} in templates-fvt creates an element from
+ * every one of those templates directly.  What is untested there, and tested here, is the step before that:
+ * something has to <em>choose</em> the template, and that choice is made by the cataloguer from the file
+ * itself.
+ * <br>
+ * The tree under test carries one file per extension for that reason, and the assertion names the type each
+ * should arrive as.
+ */
+@ExtendWith(OMAGPlatformExtension.class)
+public class FileTypeCataloguingFVT
+{
+    private static final RequestTypeDefinition CREATE_FILE_FOLDER  = RequestTypeDefinition.CREATE_FILE_FOLDER;
+    private static final RequestTypeDefinition CATALOG_FILE_FOLDER = RequestTypeDefinition.CATALOG_FILE_FOLDER;
+
+
+    @Test
+    @DisplayName("The folder cataloguer catalogues each file as the type it is")
+    void testFilesAreCataloguedAsTheirOwnType() throws Exception
+    {
+        OpenMetadataStore openMetadataStore = ConnectorContextFactory.newContext(DeleteMethod.PURGE).getOpenMetadataStore();
+
+        File   folder        = FilesFvtTestSupport.folderUnderTest("filetypes");
+        String qualifiedName = FilesFvtTestSupport.folderAssetQualifiedName(folder);
+
+        String folderAssetGUID = null;
+
+        try
+        {
+            assertTrue(folder.isDirectory(), "The folder under test was not built: " + folder.getAbsolutePath());
+
+            Map<String, String> createParameters = new HashMap<>(FilesFvtTestSupport.folderTemplatePlaceholders(folder));
+
+            String createActionGUID = new AutomatedCurationClient().initiateGovernanceActionType(
+                    FilesFvtTestSupport.governanceActionTypeQualifiedName(CREATE_FILE_FOLDER),
+                    createParameters,
+                    null);
+
+            new EngineActionWaiter().waitForCompletion(createActionGUID,
+                                                        FilesFvtTestSupport.governanceActionTypeQualifiedName(CREATE_FILE_FOLDER));
+
+            OpenMetadataElement folderAsset = FilesFvtTestSupport.waitForElement(openMetadataStore,
+                                                                                 qualifiedName,
+                                                                                 "the folder asset to catalogue");
+
+            assertNotNull(folderAsset, "No folder asset called " + qualifiedName + " arrived in the repository.");
+
+            folderAssetGUID = folderAsset.getElementGUID();
+
+            String catalogActionGUID = new AutomatedCurationClient().initiateGovernanceActionType(
+                    FilesFvtTestSupport.governanceActionTypeQualifiedName(CATALOG_FILE_FOLDER),
+                    new HashMap<>(),
+                    List.of(FilesFvtTestSupport.newActionTarget(ActionTarget.NEW_ASSET.getName(), folderAssetGUID)));
+
+            new EngineActionWaiter().waitForCompletion(catalogActionGUID,
+                                                        FilesFvtTestSupport.governanceActionTypeQualifiedName(CATALOG_FILE_FOLDER));
+
+            OMAGPlatformExtension.getIntegrationDaemonClient().refreshConnectors();
+
+            /*
+             * Wait for every file to be catalogued rather than for the first, so that the assertion below
+             * reports what each one arrived as instead of failing on whichever had not appeared yet.
+             */
+            Map<String, String> catalogued = new TreeMap<>();
+
+            FilesFvtTestSupport.waitFor("the folder cataloguer to catalogue the files in " + folder.getName(),
+                                         "files.fvt.refresh.timeout.seconds",
+                                         180,
+                                         () ->
+                                         {
+                                             catalogued.clear();
+                                             catalogued.putAll(getCataloguedTypes(openMetadataStore, folder));
+
+                                             return catalogued.keySet().containsAll(FilesFvtTestSupport.FILE_TYPE_EXPECTATIONS.keySet());
+                                         });
+
+            for (Map.Entry<String, String> expectation : FilesFvtTestSupport.FILE_TYPE_EXPECTATIONS.entrySet())
+            {
+                String fileName     = expectation.getKey();
+                String expectedType = expectation.getValue();
+
+                assertTrue(catalogued.containsKey(fileName),
+                           "The folder cataloguer did not catalogue " + fileName + ".  It catalogued: " + catalogued);
+
+                assertEquals(expectedType, catalogued.get(fileName),
+                             "The folder cataloguer catalogued " + fileName + " as a " + catalogued.get(fileName)
+                                     + " rather than a " + expectedType + ", so it did not choose the catalog template"
+                                     + " the content pack ships for that kind of file.  Everything downstream that keys"
+                                     + " off the type - which survey runs, which connector opens it - stops applying.");
+            }
+        }
+        finally
+        {
+            if (folderAssetGUID != null)
+            {
+                FilesFvtTestSupport.purgeElement(openMetadataStore, folderAssetGUID);
+            }
+        }
+    }
+
+
+    /**
+     * Return the type each file in the folder was catalogued as, keyed by file name.
+     *
+     * @param openMetadataStore store to read through
+     * @param folder folder whose files should have been catalogued
+     * @return file name to type name
+     */
+    private Map<String, String> getCataloguedTypes(OpenMetadataStore openMetadataStore,
+                                                   File              folder)
+    {
+        Map<String, String> types = new TreeMap<>();
+
+        try
+        {
+            SearchProperties searchProperties = new SearchProperties();
+
+            searchProperties.setConditions(new PropertyHelper().addStringProperty(null,
+                                                                                   OpenMetadataProperty.QUALIFIED_NAME.name,
+                                                                                   folder.getName(),
+                                                                                   PropertyComparisonOperator.LIKE));
+
+            QueryOptions queryOptions = new QueryOptions();
+
+            queryOptions.setMetadataElementTypeName(OpenMetadataType.DATA_FILE.typeName);
+            queryOptions.setPageSize(FilesFvtTestSupport.MAX_PAGE_SIZE);
+
+            List<OpenMetadataElement> found = openMetadataStore.findMetadataElements(searchProperties, null, queryOptions);
+
+            if (found != null)
+            {
+                for (OpenMetadataElement element : found)
+                {
+                    String elementQualifiedName = FilesFvtTestSupport.getStringProperty(element,
+                                                                                         OpenMetadataProperty.QUALIFIED_NAME.name);
+
+                    if (elementQualifiedName != null)
+                    {
+                        String fileName = elementQualifiedName.substring(elementQualifiedName.lastIndexOf('/') + 1);
+
+                        types.put(fileName, element.getType().getTypeName());
+                    }
+                }
+            }
+        }
+        catch (Exception error)
+        {
+            /*
+             * Read while the cataloguer is working, so a failure here is ordinary - the caller is polling.
+             */
+        }
+
+        return types;
+    }
+}

--- a/open-metadata-test/open-metadata-fvt/files-fvt/src/test/java/org/odpi/openmetadata/filesfvt/FilesFvtTestSupport.java
+++ b/open-metadata-test/open-metadata-fvt/files-fvt/src/test/java/org/odpi/openmetadata/filesfvt/FilesFvtTestSupport.java
@@ -19,6 +19,7 @@ import org.odpi.openmetadata.frameworks.openmetadata.search.PropertyComparisonOp
 import org.odpi.openmetadata.frameworks.openmetadata.search.PropertyHelper;
 import org.odpi.openmetadata.frameworks.openmetadata.search.QueryOptions;
 import org.odpi.openmetadata.frameworks.openmetadata.search.SearchProperties;
+import org.odpi.openmetadata.frameworks.openmetadata.refdata.DeployedImplementationType;
 import org.odpi.openmetadata.frameworks.openmetadata.types.OpenMetadataProperty;
 import org.odpi.openmetadata.frameworks.openmetadata.types.OpenMetadataType;
 
@@ -170,6 +171,34 @@ final class FilesFvtTestSupport
     {
         return OpenMetadataType.FILE_FOLDER.typeName + "::" + getFileSystemName() + ":" + folder.getAbsolutePath();
     }
+
+
+    /**
+     * Return the qualified name the DataFolder catalog template gives a folder asset.
+     * <br>
+     * The same shape as the FileFolder one but a different type name, because a data folder is a different
+     * kind of thing - the directory is the data set, rather than a place individual files live.
+     *
+     * @param folder the folder on disk
+     * @return qualified name to search for
+     */
+    static String dataFolderAssetQualifiedName(File folder)
+    {
+        return OpenMetadataType.DATA_FOLDER.typeName + "::" + getFileSystemName() + ":" + folder.getAbsolutePath();
+    }
+
+
+    /**
+     * The type each file in the file-types folder should be catalogued as.
+     * <br>
+     * Taken from the content pack's own templates rather than written out as strings: DeployedImplementationType
+     * is what the pack builds each template from, and its associated type name is the type the template
+     * creates.  A rename in the model is then a compile failure here rather than a test asserting a type name
+     * that no longer exists.
+     */
+    static final Map<String, String> FILE_TYPE_EXPECTATIONS =
+            Map.of("measurements.csv", DeployedImplementationType.CSV_FILE.getAssociatedTypeName(),
+                   "settings.json",    DeployedImplementationType.JSON_FILE.getAssociatedTypeName());
 
 
     /**
@@ -366,7 +395,8 @@ final class FilesFvtTestSupport
     /**
      * The folders this suite builds, one per test that needs one of its own.
      */
-    static final List<String> FOLDER_PURPOSES = List.of("survey", "catalog", "template", "actions", "destination");
+    static final List<String> FOLDER_PURPOSES = List.of("survey", "catalog", "template", "actions", "destination",
+                                                        "datafolder", "filetypes", "watchdog");
 
     /**
      * Name of the folder nested inside each folder under test.

--- a/open-metadata-test/open-metadata-fvt/files-fvt/src/test/java/org/odpi/openmetadata/filesfvt/NewFileWatchdogFVT.java
+++ b/open-metadata-test/open-metadata-fvt/files-fvt/src/test/java/org/odpi/openmetadata/filesfvt/NewFileWatchdogFVT.java
@@ -1,0 +1,124 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.filesfvt;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.odpi.openmetadata.contentpacks.core.RequestTypeDefinition;
+import org.odpi.openmetadata.frameworks.opengovernance.controls.ActionTarget;
+import org.odpi.openmetadata.frameworks.opengovernance.properties.EngineActionElement;
+import org.odpi.openmetadata.frameworks.openmetadata.connectorcontext.OpenMetadataStore;
+import org.odpi.openmetadata.frameworks.openmetadata.enums.ActivityStatus;
+import org.odpi.openmetadata.frameworks.openmetadata.enums.DeleteMethod;
+import org.odpi.openmetadata.frameworks.openmetadata.properties.OpenMetadataElement;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * NewFileWatchdogFVT starts the new-file watchdog on a folder and checks it is running.
+ * <br>
+ * A watchdog is a different shape from every other action in this suite.  The others are asked for, do their
+ * work and complete, so a test can wait for a terminal status and then assert on what was produced.  A
+ * watchdog does not complete: it starts, registers its interest in a kind of change, and stays running until
+ * something stops it.  Waiting for it to finish would time out on a watchdog that is working perfectly.
+ * <br>
+ * So what this asserts is that it started and stayed started.  That is a narrower claim than the other tests
+ * make, and worth being plain about: it does not show that the watchdog reacts to a new file, only that it is
+ * there to react.  It still catches the failure that matters most, and the one this suite has seen repeatedly
+ * in the connectors around it - a governance service that throws on start-up, which for a watchdog means an
+ * action that fails immediately instead of a watch that silently never fires.
+ * <br>
+ * Testing the reaction would mean cataloguing a new file inside the watched folder and waiting for the action
+ * the watchdog initiates in response, through a second engine action this test does not request and cannot
+ * name in advance.  That is a worthwhile test and a larger one; it is named in this suite's README as still
+ * to add rather than approximated here.
+ */
+@ExtendWith(OMAGPlatformExtension.class)
+public class NewFileWatchdogFVT
+{
+    private static final RequestTypeDefinition CREATE_FILE_FOLDER  = RequestTypeDefinition.CREATE_FILE_FOLDER;
+    private static final RequestTypeDefinition WATCH_FOR_NEW_FILES = RequestTypeDefinition.WATCH_FOR_NEW_FILES;
+
+    /**
+     * How long the watchdog is watched for before the test accepts that it is running.  Long enough that a
+     * service which throws shortly after start-up is caught, short enough not to pad the suite.
+     */
+    private static final long SETTLE_MILLISECONDS = 5000;
+
+
+    @Test
+    @DisplayName("The new-file watchdog starts on a folder and keeps running")
+    void testWatchdogStartsAndKeepsRunning() throws Exception
+    {
+        OpenMetadataStore openMetadataStore = ConnectorContextFactory.newContext(DeleteMethod.PURGE).getOpenMetadataStore();
+
+        File   folder        = FilesFvtTestSupport.folderUnderTest("watchdog");
+        String qualifiedName = FilesFvtTestSupport.folderAssetQualifiedName(folder);
+
+        String folderAssetGUID  = null;
+        String watchdogGUID     = null;
+
+        try
+        {
+            assertTrue(folder.isDirectory(), "The folder under test was not built: " + folder.getAbsolutePath());
+
+            String createActionGUID = new AutomatedCurationClient().initiateGovernanceActionType(
+                    FilesFvtTestSupport.governanceActionTypeQualifiedName(CREATE_FILE_FOLDER),
+                    new HashMap<>(FilesFvtTestSupport.folderTemplatePlaceholders(folder)),
+                    null);
+
+            new EngineActionWaiter().waitForCompletion(createActionGUID,
+                                                        FilesFvtTestSupport.governanceActionTypeQualifiedName(CREATE_FILE_FOLDER));
+
+            OpenMetadataElement folderAsset = FilesFvtTestSupport.waitForElement(openMetadataStore,
+                                                                                 qualifiedName,
+                                                                                 "the folder for the watchdog to watch");
+
+            assertNotNull(folderAsset, "No folder asset called " + qualifiedName + " arrived in the repository.");
+
+            folderAssetGUID = folderAsset.getElementGUID();
+
+            String actionName = FilesFvtTestSupport.governanceActionTypeQualifiedName(WATCH_FOR_NEW_FILES);
+
+            watchdogGUID = new AutomatedCurationClient().initiateGovernanceActionType(
+                    actionName,
+                    new HashMap<>(),
+                    List.of(FilesFvtTestSupport.newActionTarget(ActionTarget.NEW_ASSET.getName(), folderAssetGUID)));
+
+            assertNotNull(watchdogGUID,
+                          "The Automated Curation service accepted the request to run " + actionName
+                                  + " but returned no engine action to follow.");
+
+            /*
+             * Give it time to fail if it is going to.  A watchdog that throws on start-up does so almost at
+             * once; one that is working is still in progress after this.
+             */
+            Thread.sleep(SETTLE_MILLISECONDS);
+
+            EngineActionElement watchdog = new EngineActionWaiter().getEngineAction(watchdogGUID);
+
+            assertNotNull(watchdog, "The watchdog engine action " + watchdogGUID + " cannot be read back.");
+
+            assertNotEquals(ActivityStatus.FAILED, watchdog.getActionStatus(),
+                            actionName + " failed instead of watching.  It said: " + watchdog.getCompletionMessage());
+
+            assertNotEquals(ActivityStatus.INVALID, watchdog.getActionStatus(),
+                            actionName + " was rejected as invalid rather than started.  It said: "
+                                    + watchdog.getCompletionMessage());
+        }
+        finally
+        {
+            if (folderAssetGUID != null)
+            {
+                FilesFvtTestSupport.purgeElement(openMetadataStore, folderAssetGUID);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Close the paging and classification gaps, and finish files-fvt's coverage

Two strands, both finishing work started earlier in this branch rather than opening anything new: the last
places where a search could be answered incompletely, and the last gaps in files-fvt.

**Verified:** files-fvt **44 tests**, query-fvt **35 tests**, cts-fvt **13 profiles Conformant** — all green.
Whole project compiles.

## The in-memory repository had the same paging defect as PostgreSQL

`OMRSRepositoryContentHelper.formatEntityResults()` and `formatRelationshipResults()` sorted the full result
list and returned a `subList` of it, with no unique tie-break — the same shape as the PostgreSQL `ORDER BY`
fixed earlier in this branch. None of the columns a caller can sequence on is unique, and each page is a
separate call that sorts the set again, so instances that tie were free to come back in a different order
each time: an instance could move between pages and be returned twice, or skipped, while the traversal
terminated normally.

The exposure was lower than PostgreSQL's and it is worth being accurate about why: this sorts the whole set
in one JVM with a stable sort, so it only bites when the repository is written to between page fetches, where
PostgreSQL could re-resolve ties differently on every query execution even with no writes at all. Lower is
not nil, and the remedy is the same — every ordering now ends with the instance GUID.

**One judgement call to flag.** The case where no sequencing order was given, or `ANY` was, previously did no
sorting at all; it now sorts by GUID. That is a behaviour change: callers who happened to get insertion order
will now get GUID order. The reasoning is that a caller not caring *which* order they are given still needs
each page to agree with the last, and the PostgreSQL connector already sorts in that case. Leaving it
unsorted would have left paging non-deterministic in exactly the case people reach for most casually. Easy to
back out if that is the wrong call.

`cts-fvt` against the in-memory repository is the check that matters here — the conformance suite drives
paging and sequencing hard — and it reports 13 profiles Conformant.

## findMetadataElements and countMetadataElements ignored the classification filters

The classification push-down added earlier covered the by-search-string and anchor paths. These two endpoints
take their classification search in the open metadata framework's own types rather than the repository
services' ones, which is why they were left out at the time.

That gap was the worse of the two. On the search-string paths the filter was merely applied *late*, so a
caller who paged to the end still saw everything. Here nothing downstream filters at all, so
`includeOnlyClassifiedElements`/`skipClassifiedElements` were silently ignored end to end — a caller setting
one got no filtering whatsoever.

There is now an OMF-typed `addClassificationFilters` alongside the existing one, merging the same way. The
two are kept as separate methods rather than one converting to the other: a conversion would be more code
than the merge and would need maintaining against both type sets. The cost is that a `null` argument became
ambiguous at one call site, which is now an explicit cast with a comment saying why — two overloads differing
only by a type whose simple name is the same in both packages is a trap for the next reader.

## Dead code

`QueryBuilder.getDistinctPropertyJoinQuery()` removed — 49 lines, no callers anywhere in the repository.

## files-fvt: the three gaps its README named

**[DataFolderActionsFVT](open-metadata-test/open-metadata-fvt/files-fvt/src/test/java/org/odpi/openmetadata/filesfvt/DataFolderActionsFVT.java)**
— `create-data-folder`, `catalog-data-folder`, `delete-data-folder`. A `DataFolder` is not a `FileFolder`
under another name: the directory *is* the data set and its files are not catalogued separately, so the pack
ships a separate template and separate actions, and this says the second set works rather than assuming it
does because the first does.

The delete case is the one that earns its place. `delete-data-folder` is given the template and the same
placeholder values the create used, and derives the qualified name from them — it is the only action in this
suite that has to work out what it operates on. The test also asserts the **directory is still on disk**
afterwards: it removes the catalogue entry, not the data, and a test that only checked the asset had gone
would pass on a service that deleted the user's files.

**[FileTypeCataloguingFVT](open-metadata-test/open-metadata-fvt/files-fvt/src/test/java/org/odpi/openmetadata/filesfvt/FileTypeCataloguingFVT.java)**
— the folder cataloguer picks a catalog template by the kind of file it found: `.csv` arrives as a `CSVFile`,
`.json` as a `JSONFile`, not as plain `DataFile`s.

templates-fvt already creates an element from every one of the pack's file templates directly. What is
untested there, and tested here, is the step before: something has to *choose* the template, and the
cataloguer does it from the file itself. A file catalogued as the wrong type is not wrong the way a missing
asset is wrong — it is worse, because everything downstream that keys off the type (which survey runs, which
connector opens it, which rules apply) quietly stops applying. Expected types come from
`DeployedImplementationType` rather than string literals, so a rename in the model is a compile failure here.

This was the assertion I was least confident would pass, and it did — so the template selection works, and
now has a test behind it rather than an assumption.

**[NewFileWatchdogFVT](open-metadata-test/open-metadata-fvt/files-fvt/src/test/java/org/odpi/openmetadata/filesfvt/NewFileWatchdogFVT.java)**
— starts `watch-for-new-files-in-folder` and checks it is running.

**This is a narrower claim than the other tests make, and the README says so too.** A watchdog does not
complete — it starts, registers its interest and stays running — so waiting for a terminal status would time
out on one working perfectly. What is asserted is that it started and stayed started after a settle period,
which catches the failure this connector family has shown repeatedly: a service that throws on start-up, so
the watch silently never fires. It does *not* show the watchdog reacts to a new file. Doing that means
waiting for a second engine action the test never requested and cannot name in advance; it is named in "Still
to add" rather than approximated here.

## Documentation

* The **suite README** lists all nine test classes and its "Still to add" is rewritten to what is genuinely
  left: the watchdog's reaction, the file templates no governance action reaches, and the four cataloguers
  that cannot be driven without inventing a configuration.
* The **parent FVT README** entry for files-fvt now mentions the governance actions and template selection,
  having previously described only surveys and cataloguing.

## Where this leaves the branch

Both repositories now produce a deterministic total order for paging, and every path that accepts a
classification filter applies it in the query. files-fvt covers the folder survey, both file surveys, folder
and data-folder cataloguing, file-type template selection, the file provisioning actions, the data folder
lifecycle, the watchdog's start-up, all five cataloguers, and the content pack itself.

What remains on the reported issues needs a live environment rather than more code: ISSUE-79's root cause on
an engine host, and verification of the ISSUE-38 and ISSUE-54 fixes against the data that produced the
original reports.

