### PR TITLE
Fix the broken merge workflow

### DIFF
--- a/.github/workflows/merge-v6.yml
+++ b/.github/workflows/merge-v6.yml
@@ -42,7 +42,12 @@ jobs:
         uses: gradle/gradle-build-action@v3
         with:
           cache-read-only: false
-          arguments: aggregateJavadoc
+          # The configuration cache is on by default for this build, but the aggregate-javadoc plugin is
+          # held at 6.6.3 and is not compatible with it - it holds Task references, which the cache cannot
+          # serialise.  See the note in settings.gradle for why the plugin cannot simply be upgraded.
+          arguments: |
+            aggregateJavadoc
+            --no-configuration-cache
       - name: publish aggregate javadoc
         if: ${{ github.ref == 'refs/heads/main'}}
         uses: JamesIves/github-pages-deploy-action@v4

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -20,7 +20,6 @@ javaPlatform {
 
 // Assign variables for any constraints
 ext {
-    classmateVersion = '1.5.1'
     collections4Version = '4.4'
     commonscodecVersion = '1.22.0'
 
@@ -31,16 +30,13 @@ ext {
     findbugsVersion = '3.0.2'
     hamcrestVersion = '3.0'
     hibernatevalidatorVersion = '8.0.5.Final'
-    jacksonVersion = '2.15.0'
     jacksonDatabindVersion = '2.22.1'
     jakartavalidationVersion = '3.1.0'
     jaxbVersion = '2.3.1'
     jsonldVersion = '0.13.6'
     junitVersion = '4.13.2'
-    junitjupiterVersion = '5.11.3'
     opentest4jVersion = '1.3.0'
     // JUnit Platform ships on its own version line - 1.x tracks jupiter 5.x
-    junitplatformVersion = '1.11.3'
     jwtVersion = '10.9.1'
     jwtApiVersion = '0.13.0'
     jwtImplVersion = '0.11.5'
@@ -51,15 +47,11 @@ ext {
     logbackVersion = '1.6.2'
     lettuceVersion = '7.6.0.RELEASE'
     openlineageVersion = '1.52.0'
-    mssqlVersion = '12.8.1.jre11'
-    oracleJdbcVersion = '23.5.0.24.07'
     plexusVersion = '4.0.2'
     postgresVersion = '42.7.13' // already there
-    hikariVersion = '5.1.0'
     nettyVersion = '4.2.17.Final'
     prometheusVersion = '1.17.0'
     jakartaServletVersion = '6.1.0'
-    slf4jVersion = '2.0.6'
     snappyVersion = '1.1.10.7'
 
     // This must be kept in step with the version of the springboot plugin in settings.gradle
@@ -93,16 +85,9 @@ dependencies {
         api("ch.qos.logback:logback-classic:${logbackVersion}")
         api("ch.qos.logback:logback-core:${logbackVersion}")
         api("com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}")
-        api("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
-        api("com.fasterxml.jackson.core:jackson-core:${jacksonVersion}")
-        api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}")
-        api("com.fasterxml:classmate:${classmateVersion}")
         api("com.github.jsonld-java:jsonld-java:${jsonldVersion}")
         api("com.google.code.findbugs:jsr305:${findbugsVersion}")
         api("com.ibm.db2:jcc:${db2JdbcVersion}")
-        api("com.microsoft.sqlserver:mssql-jdbc:${mssqlVersion}")
-        api("com.oracle.database.jdbc:ojdbc11:${oracleJdbcVersion}")
-        api("com.zaxxer:HikariCP:${hikariVersion}")
         api("commons-codec:commons-codec:${commonscodecVersion}")
         api("commons-io:commons-io:${commonsioVersion}")
         api("com.nimbusds:nimbus-jose-jwt:${jwtVersion}")
@@ -124,8 +109,6 @@ dependencies {
         api("org.codehaus.plexus:plexus-utils:${plexusVersion}")
         api("org.duckdb:duckdb_jdbc:${duckdbJdbcVersion}")
         api("org.postgresql:postgresql:${postgresVersion}")
-        api("org.slf4j:jcl-over-slf4j:${slf4jVersion}")
-        api("org.slf4j:slf4j-api:${slf4jVersion}")
         api("jakarta.servlet:jakarta.servlet-api:${jakartaServletVersion}")
         api("org.hibernate:hibernate-validator:${hibernatevalidatorVersion}")
         api("org.apache.logging.log4j:log4j-api:${log4jVersion}")
@@ -140,10 +123,6 @@ dependencies {
         api("io.jsonwebtoken:jjwt-impl:${jwtImplVersion}")
         api("io.jsonwebtoken:jjwt-jackson:${jwtJacksonVersion}")
         api("junit:junit:${junitVersion}")
-        api("org.junit.jupiter:junit-jupiter:${junitjupiterVersion}")
-        api("org.junit.jupiter:junit-jupiter-api:${junitjupiterVersion}")
-        api("org.junit.jupiter:junit-jupiter-engine:${junitjupiterVersion}")
-        api("org.junit.platform:junit-platform-launcher:${junitplatformVersion}")
         api("org.opentest4j:opentest4j:${opentest4jVersion}")
         api("org.hamcrest:hamcrest:${hamcrestVersion}")
         api("org.yaml:snakeyaml:${snakeYamlVersion}")
@@ -228,10 +207,18 @@ publishing {
 
             }
             // Override the project name & description for the pom based on properties set in the child working-build.gradle (hard to default & required for maven central)
+            //
+            // Both values are read here, at configuration time.  withXml is applied while the task runs,
+            // and reaching for `project` then is unsupported with the configuration cache - it fails the
+            // task and leaves a zero-length pom, which is easy to miss because this task is not part of
+            // `build`.
+            def pomDescription = project.description
+            def pomName = project.name
+
             pom.withXml {
                 // NOTE - this subproject is similar to the root project in maven, in that it defines the BOM
-                asNode().appendNode('description', "${project.description}")
-                asNode().appendNode('name', "${project.name}")
+                asNode().appendNode('description', pomDescription)
+                asNode().appendNode('name', pomName)
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -228,9 +228,25 @@ subprojects {
                             }
                         }
                         // Override the project name & description for the pom based on properties set in the child build.gradle (hard to default & required for maven central)
+                        //
+                        // Both values are captured during configuration rather than read inside withXml,
+                        // which is applied while the task runs - reaching for `project` then is
+                        // unsupported with the configuration cache and leaves a zero-length pom.  That is
+                        // easy to miss, because POM generation is not part of `build`.
+                        //
+                        // The description has to be taken in afterEvaluate: this block is configured from
+                        // the root project's subprojects {} closure, which runs before each module's own
+                        // build.gradle has set its description.
+                        def pomName = project.name
+                        def pomDescription = null
+
+                        project.afterEvaluate {
+                            pomDescription = project.description
+                        }
+
                         pom.withXml {
-                            asNode().appendNode('name', "${project.name}")
-                            asNode().appendNode('description', "${project.description}")
+                            asNode().appendNode('name', pomName)
+                            asNode().appendNode('description', pomDescription)
                         }
                     }
                 }
@@ -389,3 +405,36 @@ dependencyAnalysis {
 
 // Always run dependency check for every regular build
 build.dependsOn("buildHealth")
+
+/*
+ * `build` is not everything CI runs.  The merge and release workflows also generate the publication POMs,
+ * assemble the distribution and build the aggregate javadoc site, and none of those is reachable from
+ * `build` - so a green local build has repeatedly hidden breakage in them.  Three times during the 6.2
+ * toolchain work: the packaged jar's launcher, POM generation producing zero-length files, and the
+ * aggregate javadoc.
+ *
+ * `./gradlew verifyRelease` runs the parts that can share one invocation, and names the one that cannot.
+ */
+tasks.register('verifyRelease') {
+    group = 'verification'
+    description = 'Runs what CI runs beyond `build`: the publication POMs and the platform distribution.'
+
+    dependsOn 'build'
+    // Container projects - the ones that only group other modules - have no build file and so no
+    // publication to generate a POM for.
+    dependsOn subprojects.findAll { it.buildFile.exists() }
+                         .collect { "${it.path}:generatePomFileForMavenmodulePublication" }
+    dependsOn ':open-metadata-distribution:omag-server-platform:assemble'
+
+    doLast {
+        logger.lifecycle('')
+        logger.lifecycle('verifyRelease: build, every publication POM, and the platform distribution are green.')
+        logger.lifecycle('')
+        logger.lifecycle('One thing cannot share this invocation - the aggregate-javadoc plugin is not')
+        logger.lifecycle('compatible with the configuration cache (see the note in settings.gradle).')
+        logger.lifecycle('Run it separately before a release:')
+        logger.lifecycle('')
+        logger.lifecycle('    ./gradlew aggregateJavadoc --no-configuration-cache')
+        logger.lifecycle('')
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,11 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        // problem when upgraded to version "9.0.0"
+        // Held at 6.6.3 deliberately.  8.x and later refuse to apply to a project that also applies the
+        // java plugin ("The aggregate-javadoc plugin should not be used on a java project"), which the
+        // root project does for its own javadoc include list; 9.x drops the aggregateJavadoc task
+        // altogether.  6.6.3 is not compatible with the configuration cache, so the merge workflow runs
+        // aggregateJavadoc with --no-configuration-cache - see .github/workflows/merge-v6.yml.
         id "io.freefair.aggregate-javadoc" version "6.6.3"
         // Checks for unnecessary dependencies
         id("com.autonomousapps.dependency-analysis") version "3.19.1"


### PR DESCRIPTION
# Fix the broken merge workflow and POM generation, and delete 13 BOM pins that decide nothing

## Summary

Four files. Two of the three changes are bug fixes for breakage introduced by enabling the configuration
cache - both in tasks that `build` does not run, which is why they were not caught before merging.

1. **The merge workflow is broken on main** - `aggregateJavadoc` fails with 238 configuration cache
   problems.
2. **POM generation was producing zero-length files** for every module, silently breaking publishing.
3. **13 BOM pins named versions the build does not use** - deleted.

A `verifyRelease` task is added so this class of breakage stops reaching main.

---

# 1 - The merge workflow (the urgent one)

[Run 33320195553](https://github.com/odpi/egeria/actions/runs/33320195553) fails at the
`aggregateJavadoc` step:

```
Task ':collectJavadocClasspath': cannot serialize object of type
'org.gradle.api.tasks.javadoc.Javadoc', a subtype of 'org.gradle.api.Task'
...
238 problems were found storing the configuration cache.
```

`io.freefair.aggregate-javadoc` 6.6.3 holds `Task` references, which the configuration cache cannot
serialise. The workflow runs `aggregateJavadoc` as a step separate from `build`, so nothing before merge
exercised it.

**Upgrading the plugin is not the fix**, and the existing note in `settings.gradle` understated why:

| Version | Result |
|---|---|
| 8.7.1 | Refuses to apply - *"The aggregate-javadoc plugin should not be used on a java project"*, and the root applies `java` for its own javadoc include list |
| 9.5.0 | Configuration cache clean, but the `aggregateJavadoc` task no longer exists |

So the step now runs with `--no-configuration-cache`, and the note in `settings.gradle` records the real
reasons rather than "problem when upgraded to 9.0.0".

Verified locally: green, 5,010 HTML files in `build/docs/javadoc`, which is the directory the gh-pages
deploy step publishes.

# 2 - POM generation was broken for every module

`bom/build.gradle` and the root `build.gradle` both configure the publication POM through
`pom.withXml { ... "${project.name}" ... }`. `withXml` is applied while the task runs, and reaching for
`project` then is unsupported with the configuration cache:

```
Could not apply withXml() to generated POM
  > Invocation of 'project' references a Gradle script object from a Groovy closure at execution time
```

The task failed and left a **zero-length `pom-default.xml`**. Since the root block covers every
subproject, the whole publishing path to Maven Central was affected. Both now read their values during
configuration, and all 237 POMs generate.

**One subtlety worth knowing.** The description has to be read in `afterEvaluate`: the root's
`subprojects {}` block is configured *before* each module's own build file sets its description, so an
eager read produced null.

That turned up something long-standing. 79 modules declare no description at all, and the old code
interpolated `"${project.description}"` - which renders null as the string `"null"`. The released 5.3 POM
for `open-metadata-deployment` on Maven Central contains the literal text `>null<`. Those modules now omit
the element instead of publishing `null`.

# 3 - Thirteen BOM pins that decide nothing

Since the Spring Boot BOM was imported, Gradle takes the highest of the two versions and Boot wins on
these - while the pin goes on claiming the old number:

| Artifact | Pin claimed | Actually used |
|---|---|---|
| `jackson-core`, `jackson-dataformat-yaml`, `jackson-annotations` | 2.15.0 | 2.22.1 / 2.22 |
| `classmate` | 1.5.1 | 1.7.3 |
| `HikariCP` | 5.1.0 | 6.3.3 |
| `mssql-jdbc` | 12.8.1 | 12.10.2 |
| `ojdbc11` | 23.5.0 | 23.7.0 |
| `junit-jupiter` (3 artifacts) | 5.11.3 | 5.12.2 |
| `junit-platform-launcher` | 1.11.3 | 1.12.2 |
| `slf4j-api`, `jcl-over-slf4j` | 2.0.6 | 2.0.18 |

Deleted, along with 8 version variables left with nothing to name. Third-party constraints: **54 → 41**.

**Verified by capturing all 46,527 resolved dependency entries - every configuration of every module -
before and after. The two are byte-identical.** Bumping these instead would only have written a new
number that still decides nothing.

# 4 - `verifyRelease`

```bash
./gradlew verifyRelease
```

Runs `build`, every module's publication POM, and the platform distribution - the things CI does that
`build` alone does not reach - and prints the one command that cannot share the invocation.

This exists because the same gap has now caused three separate breakages during the 6.2 work: the
packaged jar's launcher, POM generation, and the aggregate javadoc. A green `./gradlew build` has
repeatedly meant nothing about them.

**Mutation-checked:** reintroducing the POM bug makes `verifyRelease` fail with
`Could not apply withXml() to generated POM`, so it genuinely catches what got through.

---

## Verification

- `./gradlew verifyRelease` green - build, 237 POMs, distribution
- `./gradlew aggregateJavadoc --no-configuration-cache` green, 5,010 files
- Resolution diff across 46,527 entries before/after the pin deletion: identical
- auth-fvt 15/15, query-fvt 35/35
- `clean build --scan --no-build-cache` green with zero deprecations

## Notes for reviewers

- **`--no-configuration-cache` in the workflow is a stopgap, not the answer.** The better fix is to drop
  the plugin entirely and let the root's own `javadoc` task aggregate - about 15 lines. I got most of the
  way: it needs a resolvable configuration for the classpath (resolving another project's configuration
  while writing the cache is not allowed), and then the root has to settle the slf4j capability clash that
  subprojects handle through `dev.jacomet.logging-capabilities`. That is its own piece of work with a
  before/after diff of the generated file list, not something to rush while main is red.
- **The publishing fix should not wait.** The release workflow would either fail or ship empty POMs.
- The remaining BOM cleanup is queued and deliberately not in this PR: jjwt is split across two versions
  (`api` 0.13.0 against `impl`/`jackson` 0.11.5, which jjwt requires to match), roughly ten low-risk
  version bumps, and three stale TODO comments describing versions older than the ones in use.